### PR TITLE
Add Resource Collections

### DIFF
--- a/docs/account.md
+++ b/docs/account.md
@@ -1,6 +1,6 @@
 # Accounts 
 
-Tools for working with Stellar accounts. These methods can be accessed by the 
+Tools for working with Stellar accounts. These methods can be accessed by the
 `account` property on a bloom instance: `$bloom->account`:
 
 
@@ -31,7 +31,7 @@ if ($account->hasBeenLoaded()) {
 
 ### Return Type
 
-`Account`
+`Account,Error`
 
 ### Further Reading:
 
@@ -60,6 +60,37 @@ $string = $sequenceNumber->toNativeString();
 ### Return Type
 
 `Account`
+
+## transactions()
+
+Retrieve a paginated listing of an Account's transactions.
+
+Example
+```php
+$account = $bloom->account->retrieve('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
+$transactions = $bloom->account->transactions(account: $account, limit: 20, order: 'desc')
+foreach ($transactions as $transaction) {
+    // do something with the transaction resource object.
+}
+```
+
+### Parameters
+
+| Name | Type | Notes |
+| ---- | ---- | ---- |
+| $account| `Account,Addressable,string` |
+| $cursor| `string,null` | A number that points to a specific location in a collection of responses. |
+| $order| `string` | The sort order for the transactions; either 'asc' or 'desc'. Defaults to ascending if no value is set. |
+| $limit| `int` | The maximum number of records returned. Must be between 1 and 200; the default is 10. |
+| $includeFailed| `bool` | When true, failed transactions will be included in the response. Default is false. |
+
+### Return Type
+
+`TransactionResourceCollection,Error`
+
+### Further Reading:
+
+- [https://developers.stellar.org/api/resources/accounts/transactions/](https://developers.stellar.org/api/resources/accounts/transactions/)
 
 ###### This page was dynamically generated from the AccountService source code.
 

--- a/src/Account/AccountService.php
+++ b/src/Account/AccountService.php
@@ -6,11 +6,12 @@ namespace StageRightLabs\Bloom\Account;
 
 use StageRightLabs\Bloom\Horizon\AccountResource;
 use StageRightLabs\Bloom\Horizon\Error;
+use StageRightLabs\Bloom\Horizon\TransactionResourceCollection;
 use StageRightLabs\Bloom\Keypair\Keypair;
 use StageRightLabs\Bloom\Service;
 
 /**
- * Tools for working with Stellar accounts. These methods can be accessed by the 
+ * Tools for working with Stellar accounts. These methods can be accessed by the
  * `account` property on a bloom instance: `$bloom->account`:
  */
 final class AccountService extends Service
@@ -35,7 +36,7 @@ final class AccountService extends Service
      *
      * @see https://developers.stellar.org/api/resources/accounts/single/
      * @param Addressable|string $addressable
-     * @return Account
+     * @return Account|Error
      */
     public function retrieve(Addressable|string $addressable): Account|Error
     {
@@ -86,5 +87,68 @@ final class AccountService extends Service
         return $sequenceNumber
             ? $account->withSequenceNumber($sequenceNumber->increment($bump))
             : $account;
+    }
+
+    /**
+     * Retrieve a paginated listing of an Account's transactions.
+     *
+     * Example
+     * ```php
+     * $account = $bloom->account->retrieve('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
+     * $transactions = $bloom->account->transactions(account: $account, limit: 20, order: 'desc')
+     * foreach ($transactions as $transaction) {
+     *     // do something with the transaction resource object.
+     * }
+     * ```
+     *
+     * @see https://developers.stellar.org/api/resources/accounts/transactions/
+     * @param Account|Addressable|string $account
+     * @param string|null $cursor A number that points to a specific location in a collection of responses.
+     * @param string $order The sort order for the transactions; either 'asc' or 'desc'. Defaults to ascending if no value is set.
+     * @param int $limit The maximum number of records returned. Must be between 1 and 200; the default is 10.
+     * @param bool $includeFailed When true, failed transactions will be included in the response. Default is false.
+     * @return TransactionResourceCollection|Error
+     */
+    public function transactions(
+        Account|Addressable|string $account,
+        string $cursor = null,
+        string $order = 'asc',
+        int $limit = 10,
+        bool $includeFailed = false,
+    ): TransactionResourceCollection|Error {
+        // Ensure we have a valid 'order' value
+        if (!in_array($order, ['asc', 'desc'], true)) {
+            $order = 'asc';
+        }
+
+        // Ensure we have a valid 'limit' value
+        if ($limit < 1 || $limit > 200) {
+            $limit = 10;
+        }
+
+        // Normalize the account
+        $account = Account::fromAddress($account);
+
+        // Build the request URL
+        $url = $this->bloom->config->getNetworkUrl(
+            "accounts/{$account->getAddress()}/transactions",
+            [
+                'cursor'         => $cursor,
+                'order'          => $order,
+                'limit'          => $limit,
+                'include_failed' => $includeFailed
+            ]
+        );
+
+        // Make the request
+        $response = $this->bloom->horizon->get($url);
+
+        // Did we get an error?
+        if ($response instanceof Error) {
+            return $response;
+        }
+
+        // Wrap the response in a transaction resource collection.
+        return TransactionResourceCollection::fromResponse($response);
     }
 }

--- a/src/Account/AccountService.php
+++ b/src/Account/AccountService.php
@@ -49,17 +49,17 @@ final class AccountService extends Service
             $keypair = Keypair::fromAddress($addressable);
         }
 
-        $resource = $this->bloom->horizon->get(
+        $response = $this->bloom->horizon->get(
             $this->bloom->config->getNetworkUrl("accounts/{$keypair->getAddress()}")
         );
 
-        if ($resource instanceof Error) {
-            return $resource;
+        if ($response instanceof Error) {
+            return $response;
         }
 
         return (new Account())
             ->withKeyPair($keypair)
-            ->withAccountResource(AccountResource::fromResource($resource));
+            ->withAccountResource(AccountResource::fromResponse($response));
     }
 
     /**

--- a/src/Account/AccountService.php
+++ b/src/Account/AccountService.php
@@ -50,9 +50,8 @@ final class AccountService extends Service
             $keypair = Keypair::fromAddress($addressable);
         }
 
-        $response = $this->bloom->horizon->get(
-            $this->bloom->config->getNetworkUrl("accounts/{$keypair->getAddress()}")
-        );
+        $url = $this->bloom->horizon->url("accounts/{$keypair->getAddress()}");
+        $response = $this->bloom->horizon->get($url);
 
         if ($response instanceof Error) {
             return $response;
@@ -130,7 +129,7 @@ final class AccountService extends Service
         $account = Account::fromAddress($account);
 
         // Build the request URL
-        $url = $this->bloom->config->getNetworkUrl(
+        $url = $this->bloom->horizon->url(
             "accounts/{$account->getAddress()}/transactions",
             [
                 'cursor'         => $cursor,

--- a/src/Config.php
+++ b/src/Config.php
@@ -186,7 +186,11 @@ final class Config
      */
     public function getNetworkUrl(string $path = '/', array $query = []): string
     {
-        return Url::build(strval($this->state[self::NETWORK_URL]), $path, $query);
+        return Url::build(
+            strval($this->state[self::NETWORK_URL]),
+            $path,
+            array_filter($query)
+        );
     }
 
     /**

--- a/src/Config.php
+++ b/src/Config.php
@@ -177,20 +177,13 @@ final class Config
     }
 
     /**
-     * Return the network URL. You can optionally provide a path and query
-     * string values to be appended to the URL.
+     * Return the network URL.
      *
-     * @param string $path
-     * @param array<string, mixed> $query
      * @return string
      */
-    public function getNetworkUrl(string $path = '/', array $query = []): string
+    public function getNetworkUrl(): string
     {
-        return Url::build(
-            strval($this->state[self::NETWORK_URL]),
-            $path,
-            array_filter($query)
-        );
+        return strval($this->state[self::NETWORK_URL]);
     }
 
     /**

--- a/src/Envelope/EnvelopeService.php
+++ b/src/Envelope/EnvelopeService.php
@@ -56,7 +56,7 @@ final class EnvelopeService extends Service
      */
     public function post(TransactionEnvelope $envelope): TransactionResource|Error
     {
-        $url = $this->bloom->config->getNetworkUrl('transactions');
+        $url = $this->bloom->horizon->url('transactions');
         $response = $this->bloom->horizon->post($url, [
             'tx' => XDR::fresh()->write($envelope)->toBase64()
         ]);

--- a/src/Envelope/EnvelopeService.php
+++ b/src/Envelope/EnvelopeService.php
@@ -62,7 +62,7 @@ final class EnvelopeService extends Service
         ]);
 
         return (!$response instanceof Error)
-            ? TransactionResource::fromResource($response)
+            ? TransactionResource::fromResponse($response)
             : $response;
     }
 

--- a/src/Friendbot/FriendbotService.php
+++ b/src/Friendbot/FriendbotService.php
@@ -33,7 +33,7 @@ final class FriendbotService extends Service
         $response = $this->bloom->horizon->get($url);
 
         return (!$response instanceof Error)
-            ? TransactionResource::fromResource($response)
+            ? TransactionResource::fromResponse($response)
             : $response;
     }
 }

--- a/src/Horizon/HorizonService.php
+++ b/src/Horizon/HorizonService.php
@@ -18,15 +18,15 @@ final class HorizonService extends Service
      * Perform a 'GET' request.
      *
      * @param string $url
-     * @return Resource|Error
+     * @return Response|Error
      */
-    public function get(string $url): Resource|Error
+    public function get(string $url): Response|Error
     {
         $response = $this->getClient()->get($url);
 
         return $this->responseIsAnError($response)
             ? Error::fromResponse($response)
-            : Resource::fromResponse($response);
+            : $response;
     }
 
     /**
@@ -34,15 +34,15 @@ final class HorizonService extends Service
      *
      * @param string $url
      * @param array<string, string> $params
-     * @return Resource|Error
+     * @return Response|Error
      */
-    public function post(string $url, array $params = []): Resource|Error
+    public function post(string $url, array $params = []): Response|Error
     {
         $response = $this->getClient()->post($url, $params);
 
         return $this->responseIsAnError($response)
             ? Error::fromResponse($response)
-            : Resource::fromResponse($response);
+            : $response;
     }
 
     /**

--- a/src/Horizon/HorizonService.php
+++ b/src/Horizon/HorizonService.php
@@ -6,6 +6,7 @@ namespace StageRightLabs\Bloom\Horizon;
 
 use StageRightLabs\Bloom\Service;
 use StageRightLabs\Bloom\Utility\Copy;
+use StageRightLabs\Bloom\Utility\Url;
 
 final class HorizonService extends Service
 {
@@ -78,6 +79,22 @@ final class HorizonService extends Service
     private function createFakeHttpClient(): FakeHttp
     {
         return new FakeHttp($this->mockedResponses);
+    }
+
+    /**
+     * Build a Horizon endpoint URL from component parts.
+     *
+     * @param string $path
+     * @param array<string, string|int|bool|null> $parameters
+     * @return string
+     */
+    public function url($path = '/', $parameters = []): string
+    {
+        return Url::build(
+            $this->bloom->config->getNetworkUrl(),
+            $path,
+            $parameters
+        );
     }
 
     /**

--- a/src/Horizon/Resource.php
+++ b/src/Horizon/Resource.php
@@ -58,17 +58,6 @@ class Resource
     }
 
     /**
-     * Allow a child resource to be created from a parent resource.
-     *
-     * @param Resource $resource
-     * @return static
-     */
-    public static function fromResource(Resource $resource): static
-    {
-        return new static($resource->toJson(), $resource->getResponse());
-    }
-
-    /**
      * Return the original server response.
      *
      * @return Response|null

--- a/src/Horizon/Resource.php
+++ b/src/Horizon/Resource.php
@@ -16,7 +16,7 @@ class Resource
     protected ?Response $response;
 
     /**
-     * Instantiate a new class instance.
+     * Instantiate a new resource instance.
      *
      * @param Json|array<int|string, mixed>|string $payload
      * @param Response|null $response
@@ -35,7 +35,7 @@ class Resource
     }
 
     /**
-     * Create a new class instance from an array.
+     * Create a new resource instance from an array.
      *
      * @param array<string, mixed> $payload
      * @return static
@@ -46,7 +46,7 @@ class Resource
     }
 
     /**
-     * Create a new class instance from a Horizon response.
+     * Create a new resource instance from a Horizon response.
      *
      * @param Response $response
      * @throws UnexpectedValueException
@@ -58,7 +58,7 @@ class Resource
     }
 
     /**
-     * Allow a child resource to be created from the parent resource.
+     * Allow a child resource to be created from a parent resource.
      *
      * @param Resource $resource
      * @return static

--- a/src/Horizon/Resource.php
+++ b/src/Horizon/Resource.php
@@ -98,4 +98,30 @@ class Resource
     {
         return false;
     }
+
+    /**
+     * Return the links array.
+     *
+     * @return array<string, string>
+     */
+    public function getLinks(): array
+    {
+        $arr = $this->payload->getArray('_links') ?? [];
+
+        return array_reduce(array_keys($arr), function ($carry, $key) use ($arr) {
+            $carry[$key] = $arr[$key]['href'];
+            return $carry;
+        }, []);
+    }
+
+    /**
+     * Return a single link from the links array.
+     *
+     * @param string $key
+     * @return string|null
+     */
+    public function getLink(string $key): ?string
+    {
+        return $this->payload->getString("_links.{$key}.href");
+    }
 }

--- a/src/Horizon/ResourceCollection.php
+++ b/src/Horizon/ResourceCollection.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StageRightLabs\Bloom\Horizon;
+
+use ArrayAccess;
+use Countable;
+use Iterator;
+use StageRightLabs\Bloom\Exception\UnexpectedValueException;
+use StageRightLabs\Bloom\Utility\Json;
+
+/**
+ * @template TValue
+ * @implements Iterator<int, TValue>
+ * @implements ArrayAccess<int, TValue>
+ */
+class ResourceCollection implements Iterator, Countable, ArrayAccess
+{
+    /**
+     * Properties
+     */
+    protected Json $payload;
+    protected ?Response $response;
+    protected int $position = 0;
+
+    /**
+     * @var array<int, TValue>
+     */
+    protected array $arr;
+
+    /**
+     * Instantiate a new resource collection instance.
+     *
+     * @param Json|array<int|string, mixed>|string $payload
+     * @param Response|null $response
+     */
+    final public function __construct(Json|array|string $payload = '', Response $response = null)
+    {
+        // Accept the Json Payload
+        if (!$payload instanceof Json) {
+            $payload = is_array($payload)
+                ? Json::fromArray($payload)
+                : Json::of($payload);
+        }
+        $this->payload = $payload;
+
+        // Accept the response if present
+        $this->response = $response;
+
+        /** @var callable */
+        $map = [$this->getResourceClass(), 'fromArray'];
+
+        // Translate the records into individual resource classes
+        $this->arr = [];
+        foreach ($this->payload->getArray('_embedded.records') ?? [] as $resource) {
+            $this->arr[] = call_user_func($map, $resource);
+        }
+    }
+
+    /**
+     * The type of resource that makes up this collection.
+     *
+     * @return class-string
+     */
+    protected function getResourceClass(): string
+    {
+        return Resource::class;
+    }
+
+    /**
+     * Create a new resource collection instance from an array.
+     *
+     * @param array<string, mixed> $payload
+     * @return static
+     */
+    public static function fromArray(array $payload = []): static
+    {
+        return new static($payload);
+    }
+
+    /**
+     * Create a new resource collection instance from a Horizon response.
+     *
+     * @param Response $response
+     * @throws UnexpectedValueException
+     * @return static
+     */
+    public static function fromResponse(Response $response): static
+    {
+        return new static(strval($response->getBody()), $response);
+    }
+
+    /**
+     * Return the original server response.
+     *
+     * @return Response|null
+     */
+    public function getResponse(): ?Response
+    {
+        return $this->response;
+    }
+
+    /**
+     * Return the element at a given index.
+     *
+     * @param int $index
+     * @param mixed $default
+     * @return mixed
+     */
+    public function get(int $index, mixed $default = null): mixed
+    {
+        return array_key_exists($index, $this->arr)
+            ? $this->arr[$index]
+            : $default;
+    }
+
+    /**
+     * The number of elements in the array. Part of the Countable interface.
+     *
+     * @return int
+     */
+    public function count(): int
+    {
+        return count($this->arr);
+    }
+
+    /**
+     * The element at the current array position. Part of the Iterator interface.
+     *
+     * @return TValue
+     */
+    public function current(): mixed
+    {
+        return $this->arr[$this->position];
+    }
+
+    /**
+     * The current position.  Part of the Iterator interface.
+     *
+     * @return int
+     */
+    public function key(): int
+    {
+        return $this->position;
+    }
+
+    /**
+     * Advance to the next position. Part of the Iterator interface.
+     *
+     * @return void
+     */
+    public function next(): void
+    {
+        ++$this->position;
+    }
+
+    /**
+     * Return to the first position in the array.  Part of the Iterator interface.
+     *
+     * @return void
+     */
+    public function rewind(): void
+    {
+        $this->position = 0;
+    }
+
+    /**
+     * Ensure there is a valid element at the current position.
+     * Part of the Iterator interface.
+     *
+     * @return bool
+     */
+    public function valid(): bool
+    {
+        return array_key_exists($this->position, $this->arr);
+    }
+
+    /**
+     * Does an offset exist in the underlying array? Part of the ArrayAccess interface.
+     *
+     * @param mixed $offset
+     * @return bool
+     */
+    public function offsetExists(mixed $offset): bool
+    {
+        return isset($this->arr[$offset]);
+    }
+
+    /**
+     * Retrieve an offset from the underlying array. Part of the ArrayAccess interface.
+     *
+     * @param mixed $offset
+     * @return mixed
+     */
+    public function offsetGet(mixed $offset): mixed
+    {
+        return isset($this->arr[$offset])
+            ? $this->arr[$offset]
+            : null;
+    }
+
+    /**
+     * Assign a value to the specified offset. Part of the ArrayAccess interface.
+     *
+     * @param mixed $offset
+     * @param mixed $value
+     * @return void
+     */
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        if (is_null($offset)) {
+            $this->arr[] = $value;
+        } else {
+            $this->arr[intval($offset)] = $value;
+        }
+    }
+
+    /**
+     * Unset an offset. Part of the ArrayAccess interface.
+     *
+     * @param mixed $offset
+     * @return void
+     */
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->arr[$offset]);
+    }
+
+    /**
+     * Determine whether or not the array is empty.
+     *
+     * @return bool
+     */
+    public function isEmpty(): bool
+    {
+        return $this->count() == 0;
+    }
+
+    /**
+     * Determine whether or not the array is not empty.
+     *
+     * @return bool
+     */
+    public function isNotEmpty(): bool
+    {
+        return !$this->isEmpty();
+    }
+
+    /**
+     * Return the array.
+     *
+     * @return array<int, TValue>
+     */
+    public function toArray(): array
+    {
+        return $this->arr;
+    }
+}

--- a/src/Horizon/ResourceCollection.php
+++ b/src/Horizon/ResourceCollection.php
@@ -256,4 +256,40 @@ class ResourceCollection implements Iterator, Countable, ArrayAccess
     {
         return $this->arr;
     }
+
+    /**
+     * Return the links array.
+     *
+     * @return array<string, string>
+     */
+    public function getLinks(): array
+    {
+        $arr = $this->payload->getArray('_links') ?? [];
+
+        return array_reduce(array_keys($arr), function ($carry, $key) use ($arr) {
+            $carry[$key] = $arr[$key]['href'];
+            return $carry;
+        }, []);
+    }
+
+    /**
+     * Return a single link from the links array.
+     *
+     * @param string $key
+     * @return string|null
+     */
+    public function getLink(string $key): ?string
+    {
+        return $this->payload->getString("_links.{$key}.href");
+    }
+
+    /**
+     * Return the 'self' link.
+     *
+     * @return string|null
+     */
+    public function getSelfLink(): ?string
+    {
+        return $this->getLink('self');
+    }
 }

--- a/src/Horizon/ResourceCollection.php
+++ b/src/Horizon/ResourceCollection.php
@@ -9,6 +9,7 @@ use Countable;
 use Iterator;
 use StageRightLabs\Bloom\Exception\UnexpectedValueException;
 use StageRightLabs\Bloom\Utility\Json;
+use StageRightLabs\Bloom\Utility\Url;
 
 /**
  * @template TValue
@@ -291,5 +292,49 @@ class ResourceCollection implements Iterator, Countable, ArrayAccess
     public function getSelfLink(): ?string
     {
         return $this->getLink('self');
+    }
+
+    /**
+     * Return the link to the next page of transaction records, if available.
+     *
+     * @return string|null
+     */
+    public function getNextLink(): ?string
+    {
+        return $this->getLink('next');
+    }
+
+    /**
+     * Return the paging token for the next page of transaction records, if available.
+     *
+     * @return string|null
+     */
+    public function getNextPagingToken(): ?string
+    {
+        return $this->getNextLink()
+            ? Url::parameter($this->getNextLink(), 'cursor')
+            : null;
+    }
+
+    /**
+     * Return the link to the previous page of transaction records, if available.
+     *
+     * @return string|null
+     */
+    public function getPreviousLink(): ?string
+    {
+        return $this->getLink('prev');
+    }
+
+    /**
+     * Return the paging token for the previous page of transaction records, if available.
+     *
+     * @return string|null
+     */
+    public function getPreviousPagingToken(): ?string
+    {
+        return $this->getPreviousLink()
+            ? Url::parameter($this->getPreviousLink(), 'cursor')
+            : null;
     }
 }

--- a/src/Horizon/TransactionResource.php
+++ b/src/Horizon/TransactionResource.php
@@ -19,32 +19,6 @@ use StageRightLabs\PhpXdr\XDR;
 class TransactionResource extends Resource
 {
     /**
-     * Return the links array.
-     *
-     * @return array<string, string>
-     */
-    public function getLinks(): array
-    {
-        $arr = $this->payload->getArray('_links') ?? [];
-
-        return array_reduce(array_keys($arr), function ($carry, $key) use ($arr) {
-            $carry[$key] = $arr[$key]['href'];
-            return $carry;
-        }, []);
-    }
-
-    /**
-     * Return a single link from the links array.
-     *
-     * @param string $key
-     * @return string|null
-     */
-    public function getLink(string $key): ?string
-    {
-        return $this->payload->getString("_links.{$key}.href");
-    }
-
-    /**
      * Return the 'self' link.
      *
      * @return string|null

--- a/src/Horizon/TransactionResourceCollection.php
+++ b/src/Horizon/TransactionResourceCollection.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StageRightLabs\Bloom\Horizon;
+
+use StageRightLabs\Bloom\Utility\Url;
+
+/**
+ * @extends ResourceCollection<TransactionResource>
+ */
+class TransactionResourceCollection extends ResourceCollection
+{
+    /**
+     * The type of resource that makes up this collection.
+     *
+     * @return class-string
+     */
+    protected function getResourceClass(): string
+    {
+        return TransactionResource::class;
+    }
+
+    /**
+     * Return the link to the next page of transaction records, if available.
+     *
+     * @return string|null
+     */
+    public function getNextLink(): ?string
+    {
+        return $this->getLink('next');
+    }
+
+    /**
+     * Return the paging token for the next page of transaction records, if available.
+     *
+     * @return string|null
+     */
+    public function getNextPagingToken(): ?string
+    {
+        return Url::parameter($this->getNextLink(), 'cursor');
+    }
+
+    /**
+     * Return the link to the previous page of transaction records, if available.
+     *
+     * @return string|null
+     */
+    public function getPreviousLink(): ?string
+    {
+        return $this->getLink('prev');
+    }
+
+    /**
+     * Return the paging token for the previous page of transaction records, if available.
+     *
+     * @return string|null
+     */
+    public function getPreviousPagingToken(): ?string
+    {
+        return Url::parameter($this->getPreviousLink(), 'cursor');
+    }
+}

--- a/src/Horizon/TransactionResourceCollection.php
+++ b/src/Horizon/TransactionResourceCollection.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace StageRightLabs\Bloom\Horizon;
 
-use StageRightLabs\Bloom\Utility\Url;
-
 /**
  * @extends ResourceCollection<TransactionResource>
  */
@@ -19,45 +17,5 @@ class TransactionResourceCollection extends ResourceCollection
     protected function getResourceClass(): string
     {
         return TransactionResource::class;
-    }
-
-    /**
-     * Return the link to the next page of transaction records, if available.
-     *
-     * @return string|null
-     */
-    public function getNextLink(): ?string
-    {
-        return $this->getLink('next');
-    }
-
-    /**
-     * Return the paging token for the next page of transaction records, if available.
-     *
-     * @return string|null
-     */
-    public function getNextPagingToken(): ?string
-    {
-        return Url::parameter($this->getNextLink(), 'cursor');
-    }
-
-    /**
-     * Return the link to the previous page of transaction records, if available.
-     *
-     * @return string|null
-     */
-    public function getPreviousLink(): ?string
-    {
-        return $this->getLink('prev');
-    }
-
-    /**
-     * Return the paging token for the previous page of transaction records, if available.
-     *
-     * @return string|null
-     */
-    public function getPreviousPagingToken(): ?string
-    {
-        return Url::parameter($this->getPreviousLink(), 'cursor');
     }
 }

--- a/src/Primitives/Arr.php
+++ b/src/Primitives/Arr.php
@@ -26,16 +26,6 @@ use StageRightLabs\PhpXdr\XDR;
 abstract class Arr implements XdrArray, Iterator, Countable, ArrayAccess
 {
     /**
-     * Ensure there is always a valid underlying array.
-     *
-     * @param array<mixed> $arr
-     */
-    final public function __construct($arr = [])
-    {
-        $this->arr = $arr;
-    }
-
-    /**
      * @var int
      */
     protected int $position = 0;
@@ -44,6 +34,16 @@ abstract class Arr implements XdrArray, Iterator, Countable, ArrayAccess
      * @var array<int, TValue>
      */
     protected array $arr;
+
+    /**
+     * Ensure there is always a valid underlying array.
+     *
+     * @param array<mixed> $arr
+     */
+    final public function __construct($arr = [])
+    {
+        $this->arr = $arr;
+    }
 
     /**
      * Wrap an array with this class. Same as 'make' but accepts mixed values.

--- a/src/Utility/Url.php
+++ b/src/Utility/Url.php
@@ -59,18 +59,32 @@ class Url
      * @param string $url
      * @return array<int|string, array<int, string>|string>
      */
-    public static function query(string $url): array
+    public static function parameters(string $url): array
     {
-        $query = parse_url($url, PHP_URL_QUERY);
-        $query = $query ? $query : '';
-
+        $query = strval(parse_url($url, PHP_URL_QUERY));
         parse_str($query, $payload);
 
         return $payload;
     }
 
     /**
-     * Return the base of a given URL: the scheme and the authority.
+     * Extract a query string parameter from a URL.
+     *
+     * @param string $url
+     * @param string $key
+     * @return string|null
+     */
+    public static function parameter(string $url, string $key): ?string
+    {
+        $parameters = self::parameters($url);
+
+        return array_key_exists($key, $parameters)
+            ? strval($parameters[$key])
+            : null;
+    }
+
+    /**
+     * Return the base of a given URL; the scheme and the authority.
      *
      * @param string $url
      * @return string

--- a/src/Utility/Url.php
+++ b/src/Utility/Url.php
@@ -98,15 +98,36 @@ class Url
      * Build a URL from a base, path and set of optional query string parameters.
      *
      * @param string $base
-     * @param array<string, mixed> $params
+     * @param array<string, string|int|bool|null> $params
      * @return string
      */
     public static function build(string $base, string $path = '/', array $params = []): string
     {
+        // Remove null values from the parameters array
+        $params = array_filter($params, fn ($e) => $e !== null);
+
+        // Convert parameter values to strings
+        $params = array_map(function ($value) {
+            // True values will be converted to the string 'true'
+            if ($value === true) {
+                $value = 'true';
+            }
+
+            // False values will be converted to the string 'false'
+            if ($value === false) {
+                $value = 'false';
+            }
+
+            // Ensure everything else is converted to a string
+            return strval($value);
+        }, $params);
+
+        // Prepare the URL components
         $base = self::base($base);
         $path = str_starts_with($path, '/') ? $path : '/' . $path;
         $query = empty($params) ? '' : '?' . http_build_query($params);
 
+        // Return the constructed URL
         return $base . $path . $query;
     }
 }

--- a/tests/Account/AccountTest.php
+++ b/tests/Account/AccountTest.php
@@ -251,9 +251,9 @@ class AccountTest extends TestCase
      */
     public function it_accepts_an_account_resource()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
 
         $this->assertFalse($accountA->hasBeenLoaded());
         $this->assertTrue($accountB->hasBeenLoaded());
@@ -327,9 +327,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_self_link_when_available()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
 
         $this->assertNull($accountA->getSelfLink());
         $this->assertEquals('https://horizon-testnet.stellar.org/accounts/[address]', $accountB->getSelfLink());
@@ -341,9 +341,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_transactions_link_when_available()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
 
         $this->assertNull($accountA->getTransactionsLink());
         $this->assertEquals('https://horizon-testnet.stellar.org/accounts/[address]/transactions{?cursor,limit,order}', $accountB->getTransactionsLink());
@@ -355,9 +355,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_operations_link_when_available()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
 
         $this->assertNull($accountA->getOperationsLink());
         $this->assertEquals('https://horizon-testnet.stellar.org/accounts/[address]/operations{?cursor,limit,order}', $accountB->getOperationsLink());
@@ -369,9 +369,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_payments_link_when_available()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
 
         $this->assertNull($accountA->getPaymentsLink());
         $this->assertEquals('https://horizon-testnet.stellar.org/accounts/[address]/payments{?cursor,limit,order}', $accountB->getPaymentsLink());
@@ -383,9 +383,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_effects_link_when_available()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
 
         $this->assertNull($accountA->getEffectsLink());
         $this->assertEquals('https://horizon-testnet.stellar.org/accounts/[address]/effects{?cursor,limit,order}', $accountB->getEffectsLink());
@@ -397,9 +397,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_offers_link_when_available()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
 
         $this->assertNull($accountA->getOffersLink());
         $this->assertEquals('https://horizon-testnet.stellar.org/accounts/[address]/offers{?cursor,limit,order}', $accountB->getOffersLink());
@@ -411,9 +411,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_trades_link_when_available()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
 
         $this->assertNull($accountA->getTradesLink());
         $this->assertEquals('https://horizon-testnet.stellar.org/accounts/[address]/trades{?cursor,limit,order}', $accountB->getTradesLink());
@@ -425,9 +425,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_data_link_when_available()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
 
         $this->assertNull($accountA->getDataLink());
         $this->assertEquals('https://horizon-testnet.stellar.org/accounts/[address]/data/{key}', $accountB->getDataLink());
@@ -439,11 +439,11 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_resource_id()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account', [
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account', [
             'address' => 'GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW'
         ]));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
 
         $this->assertNull($accountA->getResourceId());
         $this->assertEquals('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW', $accountB->getResourceId());
@@ -455,9 +455,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_sequence_ledger()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
 
         $this->assertNull($accountA->getSequenceLedger());
         $this->assertInstanceOf(UInt32::class, $accountB->getSequenceLedger());
@@ -470,9 +470,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_sequence_time()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
 
         $this->assertNull($accountA->getSequenceTime());
         $this->assertInstanceOf(UInt64::class, $accountB->getSequenceTime());
@@ -485,9 +485,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_sub_entry_count()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
 
         $this->assertNull($accountA->getSubEntryCount());
         $this->assertInstanceOf(UInt32::class, $accountB->getSubEntryCount());
@@ -500,9 +500,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_home_domain()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
 
         $this->assertNull($accountA->getHomeDomain());
         $this->assertEquals('[domain]', $accountB->getHomeDomain());
@@ -514,9 +514,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_last_modified_ledger_sequence()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
 
         $this->assertNull($accountA->getLastModifiedLedgerSequence());
         $this->assertInstanceOf(UInt32::class, $accountB->getLastModifiedLedgerSequence());
@@ -529,9 +529,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_reserves_sponsoring_count()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
 
         $this->assertNull($accountA->getReservesSponsoringCount());
         $this->assertInstanceOf(UInt32::class, $accountB->getReservesSponsoringCount());
@@ -544,9 +544,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_reserves_sponsored_count()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
 
         $this->assertNull($accountA->getReservesSponsoredCount());
         $this->assertInstanceOf(UInt32::class, $accountB->getReservesSponsoredCount());
@@ -559,9 +559,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_sponsor_id()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
 
         $this->assertNull($accountA->getSponsorId());
         $this->assertEquals('[sponsor]', $accountB->getSponsorId());
@@ -573,9 +573,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_low_threshold()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
 
         $this->assertNull($accountA->getLowThreshold());
         $this->assertInstanceOf(UInt32::class, $accountB->getLowThreshold());
@@ -588,9 +588,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_medium_threshold()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
 
         $this->assertNull($accountA->getMediumThreshold());
         $this->assertInstanceOf(UInt32::class, $accountB->getMediumThreshold());
@@ -603,9 +603,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_high_threshold()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
 
         $this->assertNull($accountA->getHighThreshold());
         $this->assertInstanceOf(UInt32::class, $accountB->getHighThreshold());
@@ -618,9 +618,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_account_flags()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
         $expected = [
             'auth_required'         => true,
             'auth_revocable'        => true,
@@ -638,9 +638,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_auth_immutable_flag()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
 
         $this->assertNull($accountA->getAuthImmutableFlag());
         $this->assertEquals(true, $accountB->getAuthImmutableFlag());
@@ -652,9 +652,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_auth_required_flag()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
 
         $this->assertNull($accountA->getAuthRequiredFlag());
         $this->assertEquals(true, $accountB->getAuthRequiredFlag());
@@ -666,9 +666,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_auth_revocable_flag()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
 
         $this->assertNull($accountA->getAuthRevocableFlag());
         $this->assertEquals(true, $accountB->getAuthRevocableFlag());
@@ -680,9 +680,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_auth_clawback_enabled_flag()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
 
         $this->assertNull($accountA->getAuthClawbackEnabledFlag());
         $this->assertEquals(true, $accountB->getAuthClawbackEnabledFlag());
@@ -694,9 +694,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_account_balances()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
         $expected = [
             'balance'             => '10000.0000000',
             'buying_liabilities'  => '0.0000000',
@@ -715,9 +715,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_balance_for_a_given_asset()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
         $balance = $accountB->getBalanceForAsset('USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5');
 
         $this->assertInstanceOf(AccountBalanceResource::class, $balance);
@@ -732,9 +732,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_signers()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
         $expected = [
             'weight' => 1,
             'key'    => '[address]',
@@ -752,9 +752,9 @@ class AccountTest extends TestCase
      */
     public function it_returns_the_account_data()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
+        $resource = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $accountA = Account::fromAddress('GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW');
-        $accountB = $accountA->withAccountResource(AccountResource::fromResource($resource));
+        $accountB = $accountA->withAccountResource($resource);
         $expected = [
             'foo' => 'bar',
         ];

--- a/tests/Account/AccountTest.php
+++ b/tests/Account/AccountTest.php
@@ -15,7 +15,6 @@ use StageRightLabs\Bloom\Exception\InvalidKeyException;
 use StageRightLabs\Bloom\Horizon\AccountBalanceResource;
 use StageRightLabs\Bloom\Horizon\AccountResource;
 use StageRightLabs\Bloom\Horizon\AccountSignerResource;
-use StageRightLabs\Bloom\Horizon\Resource;
 use StageRightLabs\Bloom\Horizon\Response;
 use StageRightLabs\Bloom\Keypair\Keypair;
 use StageRightLabs\Bloom\Primitives\UInt32;

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -149,8 +149,7 @@ class ConfigTest extends TestCase
         $configB = $configA->withNetworkUrl('https://www.example.com');
 
         $this->assertEquals(Bloom::TEST_NETWORK_URL, $configA->getNetworkUrl());
-        $this->assertEquals('https://www.example.com/', $configB->getNetworkUrl());
-        $this->assertEquals('https://www.example.com/foo/bar?baz=bat', $configB->getNetworkUrl('foo/bar', ['baz' => 'bat']));
+        $this->assertEquals('https://www.example.com', $configB->getNetworkUrl());
     }
 
     /**

--- a/tests/Horizon/AccountResourceTest.php
+++ b/tests/Horizon/AccountResourceTest.php
@@ -8,7 +8,6 @@ use StageRightLabs\Bloom\Account\AccountId;
 use StageRightLabs\Bloom\Horizon\AccountBalanceResource;
 use StageRightLabs\Bloom\Horizon\AccountResource;
 use StageRightLabs\Bloom\Horizon\AccountSignerResource;
-use StageRightLabs\Bloom\Horizon\Resource;
 use StageRightLabs\Bloom\Horizon\Response;
 use StageRightLabs\Bloom\Primitives\UInt32;
 use StageRightLabs\Bloom\Primitives\UInt64;
@@ -26,8 +25,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_links_array()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $links = $account->getLinks();
         $expected = [
             'self'         => 'https://horizon-testnet.stellar.org/accounts/[address]',
@@ -49,9 +47,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_a_single_link()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $this->assertEquals('https://horizon-testnet.stellar.org/accounts/[address]', $account->getLink('self'));
     }
 
@@ -61,9 +57,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_self_link()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $this->assertEquals('https://horizon-testnet.stellar.org/accounts/[address]', $account->getSelfLink());
     }
 
@@ -73,9 +67,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_transactions_link()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $this->assertEquals('https://horizon-testnet.stellar.org/accounts/[address]/transactions{?cursor,limit,order}', $account->getTransactionsLink());
     }
 
@@ -85,9 +77,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_operations_link()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $this->assertEquals('https://horizon-testnet.stellar.org/accounts/[address]/operations{?cursor,limit,order}', $account->getOperationsLink());
     }
 
@@ -97,9 +87,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_payments_link()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $this->assertEquals('https://horizon-testnet.stellar.org/accounts/[address]/payments{?cursor,limit,order}', $account->getPaymentsLink());
     }
 
@@ -109,9 +97,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_effects_link()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $this->assertEquals('https://horizon-testnet.stellar.org/accounts/[address]/effects{?cursor,limit,order}', $account->getEffectsLink());
     }
 
@@ -121,9 +107,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_offers_link()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $this->assertEquals('https://horizon-testnet.stellar.org/accounts/[address]/offers{?cursor,limit,order}', $account->getOffersLink());
     }
 
@@ -133,9 +117,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_trades_link()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $this->assertEquals('https://horizon-testnet.stellar.org/accounts/[address]/trades{?cursor,limit,order}', $account->getTradesLink());
     }
 
@@ -145,9 +127,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_data_link()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $this->assertEquals('https://horizon-testnet.stellar.org/accounts/[address]/data/{key}', $account->getDataLink());
     }
 
@@ -157,9 +137,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_account_identifier()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $this->assertEquals('[address]', $account->getId());
     }
 
@@ -169,10 +147,9 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_an_account_id()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account', [
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account', [
             'address' => 'GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW'
         ]));
-        $account = AccountResource::fromResource($resource);
 
         $this->assertInstanceOf(AccountId::class, $account->getAccountId());
         $this->assertEquals(
@@ -187,10 +164,9 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_missing_account_id()
     {
-        $resource = Resource::fromResponse(Response::fake('account_without_data', [
+        $account = AccountResource::fromResponse(Response::fake('account_without_data', [
             'address' => 'GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW'
         ]));
-        $account = AccountResource::fromResource($resource);
 
         $this->assertNull($account->getAccountId());
     }
@@ -201,8 +177,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_sequence_number()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
 
         $this->assertInstanceOf(SequenceNumber::class, $account->getSequenceNumber());
         $this->assertEquals('5607590906036224', $account->getSequenceNumber()->toNativeString());
@@ -214,9 +189,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_a_missing_sequence_number()
     {
-        $resource = Resource::fromResponse(Response::fake('account_without_data'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
         $this->assertNull($account->getSequenceNumber());
     }
 
@@ -226,8 +199,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_sequence_ledger()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
 
         $this->assertInstanceOf(UInt32::class, $account->getSequenceLedger());
         $this->assertEquals(50, $account->getSequenceLedger()->toNativeInt());
@@ -239,9 +211,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_a_missing_sequence_ledger()
     {
-        $resource = Resource::fromResponse(Response::fake('account_without_data'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
         $this->assertNull($account->getSequenceLedger());
     }
 
@@ -251,8 +221,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_sequence_time()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
 
         $this->assertInstanceOf(UInt64::class, $account->getSequenceTime());
         $this->assertEquals('100', $account->getSequenceTime()->toNativeString());
@@ -264,9 +233,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_missing_sequence_time()
     {
-        $resource = Resource::fromResponse(Response::fake('account_without_data'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
         $this->assertNull($account->getSequenceTime());
     }
 
@@ -276,8 +243,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_sub_entry_count()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
 
         $this->assertInstanceOf(UInt32::class, $account->getSubEntryCount());
         $this->assertEquals(10, $account->getSubEntryCount()->toNativeInt());
@@ -289,9 +255,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_a_missing_sub_entry_count()
     {
-        $resource = Resource::fromResponse(Response::fake('account_without_data'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
         $this->assertNull($account->getSubEntryCount());
     }
 
@@ -301,9 +265,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_home_domain()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $this->assertEquals('[domain]', $account->getHomeDomain());
     }
 
@@ -313,9 +275,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_a_missing_home_domain()
     {
-        $resource = Resource::fromResponse(Response::fake('account_without_data'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
         $this->assertNull($account->getHomeDomain());
     }
 
@@ -325,8 +285,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_last_modified_ledger_sequence()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
 
         $this->assertInstanceOf(UInt32::class, $account->getLastModifiedLedgerSequence());
         $this->assertEquals(1305619, $account->getLastModifiedLedgerSequence()->toNativeInt());
@@ -338,9 +297,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_missing_last_modified_ledger_sequence()
     {
-        $resource = Resource::fromResponse(Response::fake('account_without_data'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
         $this->assertNull($account->getLastModifiedLedgerSequence());
     }
 
@@ -350,8 +307,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_reserves_sponsoring_count()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
 
         $this->assertInstanceOf(UInt32::class, $account->getReservesSponsoringCount());
         $this->assertEquals(1, $account->getReservesSponsoringCount()->toNativeInt());
@@ -363,9 +319,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_missing_reserves_sponsoring_count()
     {
-        $resource = Resource::fromResponse(Response::fake('account_without_data'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
         $this->assertNull($account->getReservesSponsoringCount());
     }
 
@@ -375,8 +329,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_reserves_sponsored_count()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
 
         $this->assertInstanceOf(UInt32::class, $account->getReservesSponsoredCount());
         $this->assertEquals(2, $account->getReservesSponsoredCount()->toNativeInt());
@@ -388,9 +341,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_missing_reserves_sponsored_count()
     {
-        $resource = Resource::fromResponse(Response::fake('account_without_data'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
         $this->assertNull($account->getReservesSponsoredCount());
     }
 
@@ -400,9 +351,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_sponsor_id()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $this->assertEquals('[sponsor]', $account->getSponsorId());
     }
 
@@ -412,9 +361,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_missing_sponsor_id()
     {
-        $resource = Resource::fromResponse(Response::fake('account_without_data'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
         $this->assertNull($account->getSponsorId());
     }
 
@@ -424,8 +371,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_low_threshold()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
 
         $this->assertInstanceOf(UInt32::class, $account->getLowThreshold());
         $this->assertEquals(1, $account->getLowThreshold()->toNativeInt());
@@ -437,9 +383,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_zero_for_missing_low_threshold()
     {
-        $resource = Resource::fromResponse(Response::fake('account_without_data'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
         $this->assertEquals(0, $account->getLowThreshold()->toNativeInt());
     }
 
@@ -449,8 +393,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_medium_threshold()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
 
         $this->assertInstanceOf(UInt32::class, $account->getMediumThreshold());
         $this->assertEquals(2, $account->getMediumThreshold()->toNativeInt());
@@ -462,9 +405,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_zero_for_missing_medium_threshold()
     {
-        $resource = Resource::fromResponse(Response::fake('account_without_data'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
         $this->assertEquals(0, $account->getMediumThreshold()->toNativeInt());
     }
 
@@ -474,8 +415,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_high_threshold()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
 
         $this->assertInstanceOf(UInt32::class, $account->getHighThreshold());
         $this->assertEquals(3, $account->getHighThreshold()->toNativeInt());
@@ -487,9 +427,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_zero_for_missing_high_threshold()
     {
-        $resource = Resource::fromResponse(Response::fake('account_without_data'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
         $this->assertEquals(0, $account->getHighThreshold()->toNativeInt());
     }
 
@@ -499,8 +437,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_flags()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $expected = [
             'auth_required'         => true,
             'auth_revocable'        => true,
@@ -517,9 +454,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_an_empty_array_for_missing_flags()
     {
-        $resource = Resource::fromResponse(Response::fake('account_without_data'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
         $this->assertEquals([], $account->getFlags());
     }
 
@@ -529,9 +464,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_auth_immutable_flag()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $this->assertTrue($account->getAuthImmutableFlag());
     }
 
@@ -541,9 +474,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_missing_auth_immutable_flag()
     {
-        $resource = Resource::fromResponse(Response::fake('account_without_data'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
         $this->assertNull($account->getAuthImmutableFlag());
     }
 
@@ -553,9 +484,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_auth_required_flag()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $this->assertTrue($account->getAuthRequiredFlag());
     }
 
@@ -565,9 +494,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_missing_auth_required_flag()
     {
-        $resource = Resource::fromResponse(Response::fake('account_without_data'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
         $this->assertNull($account->getAuthRequiredFlag());
     }
 
@@ -577,9 +504,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_auth_revocable_flag()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $this->assertTrue($account->getAuthRevocableFlag());
     }
 
@@ -589,9 +514,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_missing_auth_revocable_flag()
     {
-        $resource = Resource::fromResponse(Response::fake('account_without_data'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
         $this->assertNull($account->getAuthRevocableFlag());
     }
 
@@ -601,9 +524,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_auth_clawback_enabled_flag()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $this->assertTrue($account->getAuthClawbackEnabledFlag());
     }
 
@@ -613,9 +534,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_missing_auth_clawback_enabled_flag()
     {
-        $resource = Resource::fromResponse(Response::fake('account_without_data'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
         $this->assertNull($account->getAuthClawbackEnabledFlag());
     }
 
@@ -625,8 +544,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_account_balances()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $expected = [
             'balance'             => '10000.0000000',
             'buying_liabilities'  => '0.0000000',
@@ -644,9 +562,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_an_empty_array_for_missing_balances()
     {
-        $resource = Resource::fromResponse(Response::fake('account_without_data'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
         $this->assertEquals([], $account->getBalances());
     }
 
@@ -656,8 +572,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_a_balance_for_a_given_asset_if_it_is_present()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $balance = $account->getBalanceForAsset('USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5');
 
         $this->assertInstanceOf(AccountBalanceResource::class, $balance);
@@ -671,8 +586,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_a_balance_for_the_native_asset()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $balance = $account->getBalanceForAsset('XLM');
 
         $this->assertInstanceOf(AccountBalanceResource::class, $balance);
@@ -686,9 +600,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_a_missing_asset()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $this->assertNull($account->getBalanceForAsset('FooBar:GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW'));
     }
 
@@ -698,8 +610,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_signers()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $expected = [
             'weight' => 1,
             'key'    => '[address]',
@@ -716,9 +627,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_an_empty_array_for_missing_signers()
     {
-        $resource = Resource::fromResponse(Response::fake('account_without_data'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
         $this->assertEquals([], $account->getSigners());
     }
 
@@ -728,8 +637,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_data_fields_array()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $expected = [
             'foo' => 'bar',
         ];
@@ -743,9 +651,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_an_empty_array_for_missing_data_fields()
     {
-        $resource = Resource::fromResponse(Response::fake('account_without_data'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
         $this->assertEquals([], $account->getData());
     }
 
@@ -755,9 +661,7 @@ class AccountResourceTest extends TestCase
      */
     public function it_can_return_a_specific_data_key_value()
     {
-        $resource = Resource::fromResponse(Response::fake('retrieve_account'));
-        $account = AccountResource::fromResource($resource);
-
+        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
         $this->assertEquals('bar', $account->getData('foo'));
     }
 }

--- a/tests/Horizon/HorizonServiceTest.php
+++ b/tests/Horizon/HorizonServiceTest.php
@@ -73,6 +73,20 @@ class HorizonServiceTest extends TestCase
 
     /**
      * @test
+     * @covers ::url
+     */
+    public function it_can_build_an_endpoint_url()
+    {
+        $bloom = new Bloom([
+            'network_url' => 'https://www.example.com'
+        ]);
+        $url = $bloom->horizon->url('foo/bar', ['baz' => 'bat']);
+
+        $this->assertEquals('https://www.example.com/foo/bar?baz=bat', $url);
+    }
+
+    /**
+     * @test
      * @covers ::withResponse
      * @covers ::hasMockedResponses
      */

--- a/tests/Horizon/HorizonServiceTest.php
+++ b/tests/Horizon/HorizonServiceTest.php
@@ -26,9 +26,9 @@ class HorizonServiceTest extends TestCase
         $bloom = Bloom::fake();
         $bloom->horizon->withResponse(new Response(200, [], 'fake resource'));
 
-        $resource = $bloom->horizon->get('some/url');
+        $response = $bloom->horizon->get('some/url');
 
-        $this->assertEquals($resource->getResponse()->getBody(), 'fake resource');
+        $this->assertEquals($response->getBody(), 'fake resource');
     }
 
     /**
@@ -40,11 +40,11 @@ class HorizonServiceTest extends TestCase
         $bloom = Bloom::fake();
         $bloom->horizon->withResponse(new Response(200, [], 'fake resource'));
 
-        $resource = $bloom->horizon->post('some/url', [
+        $response = $bloom->horizon->post('some/url', [
             'foo' => 'bar',
         ]);
 
-        $this->assertEquals($resource->getResponse()->getBody(), 'fake resource');
+        $this->assertEquals($response->getBody(), 'fake resource');
     }
 
     /**

--- a/tests/Horizon/ResourceCollectionTest.php
+++ b/tests/Horizon/ResourceCollectionTest.php
@@ -236,4 +236,34 @@ class ResourceCollectionTest extends TestCase
             $collection->getSelfLink()
         );
     }
+
+    /**
+     * @test
+     * @covers ::getNextLink
+     * @covers ::getNextPagingToken
+     */
+    public function it_returns_the_link_to_the_next_page_of_transactions()
+    {
+        $collection = ResourceCollection::fromResponse(Response::fake('account_transactions'));
+        $this->assertEquals(
+            'https://horizon-testnet.stellar.org/accounts/GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW/transactions?cursor=1116579827830784&limit=10&order=asc',
+            $collection->getNextLink()
+        );
+        $this->assertEquals('1116579827830784', $collection->getNextPagingToken());
+    }
+
+    /**
+     * @test
+     * @covers ::getPreviousLink
+     * @covers ::getPreviousPagingToken
+     */
+    public function it_returns_the_link_to_the_previous_page_of_transactions()
+    {
+        $collection = ResourceCollection::fromResponse(Response::fake('account_transactions'));
+        $this->assertEquals(
+            'https://horizon-testnet.stellar.org/accounts/GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW/transactions?cursor=1115351467184128&limit=10&order=desc',
+            $collection->getPreviousLink()
+        );
+        $this->assertEquals('1115351467184128', $collection->getPreviousPagingToken());
+    }
 }

--- a/tests/Horizon/ResourceCollectionTest.php
+++ b/tests/Horizon/ResourceCollectionTest.php
@@ -193,4 +193,47 @@ class ResourceCollectionTest extends TestCase
         $this->assertTrue(is_array($arr));
         $this->assertCount(2, $arr);
     }
+
+    /**
+     * @test
+     * @covers ::getLinks
+     */
+    public function it_returns_the_links()
+    {
+        $collection = ResourceCollection::fromResponse(Response::fake('account_transactions'));
+        $links = $collection->getLinks();
+        $expected = [
+            'self' => 'https://horizon-testnet.stellar.org/accounts/GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW/transactions?cursor=&limit=10&order=asc',
+            'next' => 'https://horizon-testnet.stellar.org/accounts/GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW/transactions?cursor=1116579827830784&limit=10&order=asc',
+            'prev' => 'https://horizon-testnet.stellar.org/accounts/GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW/transactions?cursor=1115351467184128&limit=10&order=desc'
+        ];
+
+        $this->assertEquals($expected, $links);
+    }
+
+    /**
+     * @test
+     * @covers ::getLink
+     */
+    public function it_returns_a_single_link()
+    {
+        $collection = ResourceCollection::fromResponse(Response::fake('account_transactions'));
+        $this->assertEquals(
+            'https://horizon-testnet.stellar.org/accounts/GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW/transactions?cursor=&limit=10&order=asc',
+            $collection->getLink('self')
+        );
+    }
+
+    /**
+     * @test
+     * @covers ::getSelfLink
+     */
+    public function it_returns_the_self_link()
+    {
+        $collection = ResourceCollection::fromResponse(Response::fake('account_transactions'));
+        $this->assertEquals(
+            'https://horizon-testnet.stellar.org/accounts/GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW/transactions?cursor=&limit=10&order=asc',
+            $collection->getSelfLink()
+        );
+    }
 }

--- a/tests/Horizon/ResourceCollectionTest.php
+++ b/tests/Horizon/ResourceCollectionTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StageRightLabs\Bloom\Tests\Horizon;
+
+use StageRightLabs\Bloom\Horizon\Resource;
+use StageRightLabs\Bloom\Horizon\ResourceCollection;
+use StageRightLabs\Bloom\Horizon\Response;
+use StageRightLabs\Bloom\Tests\TestCase;
+
+/**
+ * @coversDefaultClass \StageRightLabs\Bloom\Horizon\ResourceCollection
+ */
+class ResourceCollectionTest extends TestCase
+{
+    /**
+     * @test
+     * @covers ::__construct
+     * @covers ::getResourceClass
+     */
+    public function it_can_be_instantiated_with_an_array_payload()
+    {
+        $collection = new ResourceCollection([
+            '_embedded' => [
+                'records' => [
+                    ['foo' => 'bar'],
+                    ['foo' => 'bar']
+                ]
+            ]
+        ]);
+
+        $this->assertInstanceOf(ResourceCollection::class, $collection);
+        foreach ($collection as $resource) {
+            $this->assertInstanceOf(Resource::class, $resource);
+        }
+    }
+
+    /**
+     * @test
+     * @covers ::__construct
+     * @covers ::getResourceClass
+     */
+    public function it_can_be_instantiated_from_a_json_string()
+    {
+        $collection = new ResourceCollection('{"_embedded":{"records":[{"foo":"bar"},{"foo":"bar"}]}}');
+
+        $this->assertInstanceOf(ResourceCollection::class, $collection);
+        foreach ($collection as $resource) {
+            $this->assertInstanceOf(Resource::class, $resource);
+        }
+    }
+
+    /**
+     * @test
+     * @covers ::fromArray
+     */
+    public function it_can_be_instantiated_from_an_array()
+    {
+        $collection = ResourceCollection::fromArray([
+            '_embedded' => [
+                'records' => [
+                    ['foo' => 'bar'],
+                    ['foo' => 'bar']
+                ]
+            ]
+        ]);
+
+        $this->assertInstanceOf(ResourceCollection::class, $collection);
+        foreach ($collection as $resource) {
+            $this->assertInstanceOf(Resource::class, $resource);
+        }
+    }
+
+    /**
+     * @test
+     * @covers ::fromResponse
+     * @covers ::getResponse
+     */
+    public function it_can_be_instantiated_from_a_response()
+    {
+        $collection = ResourceCollection::fromResponse(Response::fake('account_transactions'));
+
+        $this->assertInstanceOf(ResourceCollection::class, $collection);
+        $this->assertInstanceOf(Response::class, $collection->getResponse());
+    }
+
+    /**
+     * @test
+     * @covers ::get
+     */
+    public function it_can_fetch_the_element_at_a_given_index()
+    {
+        $collection = ResourceCollection::fromResponse(Response::fake('account_transactions'));
+        $this->assertInstanceOf(Resource::class, $collection->get(0));
+    }
+
+    /**
+     * @test
+     * @covers ::count
+     */
+    public function it_can_return_a_count_of_collection_members()
+    {
+        $collection = ResourceCollection::fromResponse(Response::fake('account_transactions'));
+        $this->assertCount(2, $collection);
+    }
+
+    /**
+     * @test
+     * @covers ::current
+     * @covers ::key
+     * @covers ::next
+     * @covers ::rewind
+     * @covers ::valid
+     */
+    public function it_implements_the_iterator_interface()
+    {
+        $collection = ResourceCollection::fromResponse(Response::fake('account_transactions'));
+
+        // current()
+        $this->assertInstanceOf(Resource::class, $collection->current());
+
+        // key()
+        $this->assertEquals(0, $collection->key());
+
+        // next()
+        $collection->next();
+        $this->assertEquals(1, $collection->key());
+
+        // rewind()
+        $collection->rewind();
+        $this->assertEquals(0, $collection->key());
+
+        // valid()
+        $this->assertTrue($collection->valid());
+    }
+
+    /**
+     * @test
+     * @covers ::offsetExists
+     * @covers ::offsetGet
+     * @covers ::offsetSet
+     * @covers ::offsetUnset
+     */
+    public function it_implements_the_array_access_interface()
+    {
+        $collection = ResourceCollection::fromResponse(Response::fake('account_transactions'));
+
+        // offsetExists
+        $this->assertTrue($collection->offsetExists(0));
+        $this->assertFalse($collection->offsetExists(2));
+
+        // offsetGet
+        $this->assertInstanceOf(Resource::class, $collection->offsetGet(0));
+        $this->assertNull($collection->offsetGet(2));
+
+        // offsetSet
+        $collection->offsetSet(2, new Resource());
+        $collection->offsetSet(null, new Resource());
+        $this->assertInstanceOf(Resource::class, $collection->offsetGet(2));
+        $this->assertInstanceOf(Resource::class, $collection->offsetGet(3));
+
+        // offsetUnset
+        $collection->offsetUnset(2);
+        $this->assertNull($collection->offsetGet(2));
+    }
+
+    /**
+     * @test
+     * @covers ::isEmpty
+     * @covers ::isNotEmpty
+     */
+    public function it_knows_when_it_is_empty()
+    {
+        $collectionA = ResourceCollection::fromResponse(Response::fake('account_transactions'));
+        $collectionB = new ResourceCollection();
+
+        $this->assertFalse($collectionA->isEmpty());
+        $this->assertTrue($collectionB->isEmpty());
+        $this->assertTrue($collectionA->isNotEmpty());
+        $this->assertFalse($collectionB->isNotEmpty());
+    }
+
+    /**
+     * @test
+     * @covers ::toArray
+     */
+    public function it_can_be_converted_to_an_array()
+    {
+        $collection = ResourceCollection::fromResponse(Response::fake('account_transactions'));
+        $arr = $collection->toArray();
+
+        $this->assertTrue(is_array($arr));
+        $this->assertCount(2, $arr);
+    }
+}

--- a/tests/Horizon/ResourceTest.php
+++ b/tests/Horizon/ResourceTest.php
@@ -6,7 +6,6 @@ namespace StageRightLabs\Bloom\Tests\Horizon;
 
 use StageRightLabs\Bloom\Horizon\Resource;
 use StageRightLabs\Bloom\Horizon\Response;
-use StageRightLabs\Bloom\Horizon\TransactionResource;
 use StageRightLabs\Bloom\Tests\TestCase;
 use StageRightLabs\Bloom\Utility\Json;
 

--- a/tests/Horizon/ResourceTest.php
+++ b/tests/Horizon/ResourceTest.php
@@ -114,4 +114,38 @@ class ResourceTest extends TestCase
         $resource = Resource::fromResponse(Response::fake('example'));
         $this->assertFalse($resource->requestFailed());
     }
+
+    /**
+     * @test
+     * @covers ::getLinks
+     */
+    public function it_returns_the_links_array()
+    {
+        $transaction = Resource::fromResponse(Response::fake('friendbot_transaction'));
+        $links = $transaction->getLinks();
+        $expected = [
+            'self'        => 'https://horizon-testnet.stellar.org/transactions/[hash]',
+            'account'     => 'https://horizon-testnet.stellar.org/accounts/[address]',
+            'ledger'      => 'https://horizon-testnet.stellar.org/ledgers/994571',
+            'operations'  => 'https://horizon-testnet.stellar.org/transactions/[hash]/operations{?cursor,limit,order}',
+            'effects'     => 'https://horizon-testnet.stellar.org/transactions/[hash]/effects{?cursor,limit,order}',
+            'precedes'    => 'https://horizon-testnet.stellar.org/transactions?order=asc&cursor=4271649918558208',
+            'succeeds'    => 'https://horizon-testnet.stellar.org/transactions?order=desc&cursor=4271649918558208',
+            'transaction' => 'https://horizon-testnet.stellar.org/transactions/[hash]',
+        ];
+
+        $this->assertEquals($expected, $links);
+    }
+
+    /**
+     * @test
+     * @covers ::getLink
+     */
+    public function it_returns_a_single_link_from_the_links_array()
+    {
+        $transaction = Resource::fromResponse(Response::fake('friendbot_transaction'));
+        $expected = 'https://horizon-testnet.stellar.org/transactions/[hash]';
+
+        $this->assertEquals($expected, $transaction->getLink('self'));
+    }
 }

--- a/tests/Horizon/ResourceTest.php
+++ b/tests/Horizon/ResourceTest.php
@@ -88,19 +88,6 @@ class ResourceTest extends TestCase
 
     /**
      * @test
-     * @covers ::fromResource
-     */
-    public function a_child_resource_can_be_created_from_a_generic_resource()
-    {
-        $resource = Resource::fromResponse(Response::fake('example'));
-        $child = TransactionResource::fromResource($resource);
-
-        $this->assertInstanceOf(TransactionResource::class, $child);
-        $this->assertEquals(['[foo]' => '[bar]'], $child->toJson()->getAll());
-    }
-
-    /**
-     * @test
      * @covers ::toArray
      */
     public function it_can_be_converted_to_an_array()

--- a/tests/Horizon/TransactionResourceCollectionTest.php
+++ b/tests/Horizon/TransactionResourceCollectionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StageRightLabs\Bloom\Tests\Horizon;
+
+use StageRightLabs\Bloom\Horizon\Response;
+use StageRightLabs\Bloom\Horizon\TransactionResource;
+use StageRightLabs\Bloom\Horizon\TransactionResourceCollection;
+use StageRightLabs\Bloom\Tests\TestCase;
+
+/**
+ * @coversDefaultClass \StageRightLabs\Bloom\Horizon\TransactionResourceCollection
+ */
+class TransactionResourceCollectionTest extends TestCase
+{
+    /**
+     * @test
+     * @covers ::getResourceClass
+     */
+    public function it_defines_an_underlying_resource_class()
+    {
+        $collection = TransactionResourceCollection::fromResponse(Response::fake('account_transactions'));
+
+        foreach ($collection as $r) {
+            $this->assertInstanceOf(TransactionResource::class, $r);
+        }
+    }
+
+    /**
+     * @test
+     * @covers ::getNextLink
+     * @covers ::getNextPagingToken
+     */
+    public function it_returns_the_link_to_the_next_page_of_transactions()
+    {
+        $collection = TransactionResourceCollection::fromResponse(Response::fake('account_transactions'));
+        $this->assertEquals(
+            'https://horizon-testnet.stellar.org/accounts/GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW/transactions?cursor=1116579827830784&limit=10&order=asc',
+            $collection->getNextLink()
+        );
+        $this->assertEquals('1116579827830784', $collection->getNextPagingToken());
+    }
+
+    /**
+     * @test
+     * @covers ::getPreviousLink
+     * @covers ::getPreviousPagingToken
+     */
+    public function it_returns_the_link_to_the_previous_page_of_transactions()
+    {
+        $collection = TransactionResourceCollection::fromResponse(Response::fake('account_transactions'));
+        $this->assertEquals(
+            'https://horizon-testnet.stellar.org/accounts/GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW/transactions?cursor=1115351467184128&limit=10&order=desc',
+            $collection->getPreviousLink()
+        );
+        $this->assertEquals('1115351467184128', $collection->getPreviousPagingToken());
+    }
+}

--- a/tests/Horizon/TransactionResourceCollectionTest.php
+++ b/tests/Horizon/TransactionResourceCollectionTest.php
@@ -26,34 +26,4 @@ class TransactionResourceCollectionTest extends TestCase
             $this->assertInstanceOf(TransactionResource::class, $r);
         }
     }
-
-    /**
-     * @test
-     * @covers ::getNextLink
-     * @covers ::getNextPagingToken
-     */
-    public function it_returns_the_link_to_the_next_page_of_transactions()
-    {
-        $collection = TransactionResourceCollection::fromResponse(Response::fake('account_transactions'));
-        $this->assertEquals(
-            'https://horizon-testnet.stellar.org/accounts/GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW/transactions?cursor=1116579827830784&limit=10&order=asc',
-            $collection->getNextLink()
-        );
-        $this->assertEquals('1116579827830784', $collection->getNextPagingToken());
-    }
-
-    /**
-     * @test
-     * @covers ::getPreviousLink
-     * @covers ::getPreviousPagingToken
-     */
-    public function it_returns_the_link_to_the_previous_page_of_transactions()
-    {
-        $collection = TransactionResourceCollection::fromResponse(Response::fake('account_transactions'));
-        $this->assertEquals(
-            'https://horizon-testnet.stellar.org/accounts/GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW/transactions?cursor=1115351467184128&limit=10&order=desc',
-            $collection->getPreviousLink()
-        );
-        $this->assertEquals('1115351467184128', $collection->getPreviousPagingToken());
-    }
 }

--- a/tests/Horizon/TransactionResourceTest.php
+++ b/tests/Horizon/TransactionResourceTest.php
@@ -11,7 +11,6 @@ use StageRightLabs\Bloom\Cryptography\Signature;
 use StageRightLabs\Bloom\Cryptography\SignatureHint;
 use StageRightLabs\Bloom\Envelope\TransactionEnvelope;
 use StageRightLabs\Bloom\Envelope\TransactionV1Envelope;
-use StageRightLabs\Bloom\Horizon\Resource;
 use StageRightLabs\Bloom\Horizon\Response;
 use StageRightLabs\Bloom\Horizon\TransactionResource;
 use StageRightLabs\Bloom\Operation\OperationMeta;
@@ -37,8 +36,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_links_array()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
         $links = $transaction->getLinks();
         $expected = [
             'self'        => 'https://horizon-testnet.stellar.org/transactions/[hash]',
@@ -60,8 +58,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_a_single_link_from_the_links_array()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
         $expected = 'https://horizon-testnet.stellar.org/transactions/[hash]';
 
         $this->assertEquals($expected, $transaction->getLink('self'));
@@ -73,8 +70,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_self_link()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
         $expected = 'https://horizon-testnet.stellar.org/transactions/[hash]';
 
         $this->assertEquals($expected, $transaction->getSelfLink());
@@ -86,8 +82,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_account_link()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction', ['address' => 'ABCD']));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction', ['address' => 'ABCD']));
         $expected = 'https://horizon-testnet.stellar.org/accounts/ABCD';
 
         $this->assertEquals($expected, $transaction->getAccountLink());
@@ -99,8 +94,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_ledger_link()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
         $expected = 'https://horizon-testnet.stellar.org/ledgers/994571';
 
         $this->assertEquals($expected, $transaction->getLedgerLink());
@@ -112,8 +106,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_operations_link()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
         $expected = 'https://horizon-testnet.stellar.org/transactions/[hash]/operations{?cursor,limit,order}';
 
         $this->assertEquals($expected, $transaction->getOperationsLink());
@@ -125,8 +118,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_effects_link()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
         $expected = 'https://horizon-testnet.stellar.org/transactions/[hash]/effects{?cursor,limit,order}';
 
         $this->assertEquals($expected, $transaction->getEffectsLink());
@@ -138,8 +130,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_precedes_link()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
         $expected = 'https://horizon-testnet.stellar.org/transactions?order=asc&cursor=4271649918558208';
 
         $this->assertEquals($expected, $transaction->getPrecedesLink());
@@ -151,8 +142,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_succeeds_link()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
         $expected = 'https://horizon-testnet.stellar.org/transactions?order=desc&cursor=4271649918558208';
 
         $this->assertEquals($expected, $transaction->getSucceedsLink());
@@ -164,8 +154,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_transaction_id()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
         $expected = '[hash]';
 
         $this->assertEquals($expected, $transaction->getId());
@@ -177,8 +166,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_paging_token()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
         $expected = '4271649918558208';
 
         $this->assertEquals($expected, $transaction->getPagingToken());
@@ -190,9 +178,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_success_status()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction'));
-        $transaction = TransactionResource::fromResource($resource);
-
+        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
         $this->assertTrue($transaction->wasSuccessful());
     }
 
@@ -202,8 +188,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_transaction_hash()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
         $expected = '[hash]';
 
         $this->assertEquals($expected, $transaction->getHash());
@@ -215,8 +200,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_ledger_sequence()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
         $expected = '994571';
 
         $this->assertEquals($expected, $transaction->getLedgerSequence());
@@ -228,8 +212,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_created_at_date()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
         $expected = new \DateTime('2022-05-15T21:41:56Z');
 
         $this->assertEquals($expected, $transaction->getCreatedAt());
@@ -241,9 +224,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_null_for_created_at_if_no_date_is_present()
     {
-        $resource = Resource::fromResponse(Response::fake('transaction_without_created_at'));
-        $transaction = TransactionResource::fromResource($resource);
-
+        $transaction = TransactionResource::fromResponse(Response::fake('transaction_without_created_at'));
         $this->assertNull($transaction->getCreatedAt());
     }
 
@@ -253,8 +234,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_source_account_address()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction', ['address' => 'ABCD']));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction', ['address' => 'ABCD']));
         $expected = 'ABCD';
 
         $this->assertEquals($expected, $transaction->getSourceAccountAddress());
@@ -266,8 +246,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_source_account_sequence()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
         $expected = '3133127102824503';
 
         $this->assertEquals($expected, $transaction->getSourceAccountSequence());
@@ -279,9 +258,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_fee_charged()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction'));
-        $transaction = TransactionResource::fromResource($resource);
-
+        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
         $this->assertEquals('0.0010000', $transaction->getFeeCharged()->toNativeString());
     }
 
@@ -291,9 +268,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_null_for_missing_fee_charged()
     {
-        $resource = Resource::fromResponse(Response::fake('transaction_without_fee_charged'));
-        $transaction = TransactionResource::fromResource($resource);
-
+        $transaction = TransactionResource::fromResponse(Response::fake('transaction_without_fee_charged'));
         $this->assertNull($transaction->getFeeCharged());
     }
 
@@ -303,9 +278,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_max_fee()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction'));
-        $transaction = TransactionResource::fromResource($resource);
-
+        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
         $this->assertEquals('0.1000000', $transaction->getMaxFee()->toNativeString());
     }
 
@@ -315,9 +288,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_null_for_missing_max_fee()
     {
-        $resource = Resource::fromResponse(Response::fake('transaction_without_max_fee'));
-        $transaction = TransactionResource::fromResource($resource);
-
+        $transaction = TransactionResource::fromResponse(Response::fake('transaction_without_max_fee'));
         $this->assertNull($transaction->getMaxFee());
     }
 
@@ -327,9 +298,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_operation_count()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction'));
-        $transaction = TransactionResource::fromResource($resource);
-
+        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
         $this->assertEquals(1, $transaction->getOperationCount());
     }
 
@@ -339,8 +308,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_envelope_xdr()
     {
-        $resource = Resource::fromResponse(Response::fake('transaction_submitted'));
-        $transactionResource = TransactionResource::fromResource($resource);
+        $transactionResource = TransactionResource::fromResponse(Response::fake('transaction_submitted'));
         $expected = '[envelope_xdr]';
 
         $this->assertEquals($expected, $transactionResource->getEnvelopeXdr());
@@ -367,10 +335,9 @@ class TransactionResourceTest extends TestCase
             ->withSignatures($signatureList);
         $buffer = XDR::fresh()->write($envelope);
 
-        $resource = Resource::fromResponse(Response::fake('transaction_submitted', [
+        $transactionResource = TransactionResource::fromResponse(Response::fake('transaction_submitted', [
             'envelope_xdr' => $buffer->toBase64()
         ]));
-        $transactionResource = TransactionResource::fromResource($resource);
 
         $decoded = $transactionResource->getEnvelope();
 
@@ -383,9 +350,7 @@ class TransactionResourceTest extends TestCase
      */
     public function the_envelope_returns_null_if_xdr_decoding_fails()
     {
-        $resource = Resource::fromResponse(Response::fake('transaction_submitted'));
-        $transactionResource = TransactionResource::fromResource($resource);
-
+        $transactionResource = TransactionResource::fromResponse(Response::fake('transaction_submitted'));
         $this->assertNull($transactionResource->getEnvelope());
     }
 
@@ -395,8 +360,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_result_xdr()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
         $expected = 'AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=';
 
         $this->assertEquals($expected, $transaction->getResultXdr());
@@ -408,8 +372,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_decoded_result()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction'));
-        $transactionA = TransactionResource::fromResource($resource);
+        $transactionA = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
         $transactionB = new TransactionResource();
 
         $this->assertInstanceOf(TransactionResult::class, $transactionA->getResult());
@@ -422,8 +385,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_result_meta_xdr()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
         $expected = 'AAAAAgAAAAIAAAADABZvBAAAAAAAAAAAvVwFT3+rSlZXIxuRDhJnGNK1hmUGgR7Iz1Fs6Mi8yPgAAAAAPDNgHAAWaesAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABABZvBAAAAAAAAAAAvVwFT3+rSlZXIxuRDhJnGNK1hmUGgR7Iz1Fs6Mi8yPgAAAAAPDNgHAAWaesAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAwAAAAAAFm8EAAAAAGOXevYAAAAAAAAAAQAAAAMAAAADABZvAgAAAAAAAAAAEH3Rayw4M0iCLoEe96rPFNGYim8AVHJU0z4ebYZW4JwAXyFoHjXfuAAAATsAAAHXAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAwAAAAAAFmoCAAAAAGOXYMUAAAAAAAAAAQAWbwQAAAAAAAAAABB90WssODNIgi6BHveqzxTRmIpvAFRyVNM+Hm2GVuCcAF8hUNW+97gAAAE7AAAB1wAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAMAAAAAABZqAgAAAABjl2DFAAAAAAAAAAAAFm8EAAAAAAAAAACgG04mjMWmD5gmfeWpY2/Ogov+50UUsejfFOdqR9nGMAAAABdIdugAABZvBAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAA=';
 
         $this->assertEquals($expected, $transaction->getResultMetaXdr());
@@ -435,8 +397,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_decoded_result_meta()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction'));
-        $transactionA = TransactionResource::fromResource($resource);
+        $transactionA = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
         $transactionB = new TransactionResource();
 
         $this->assertInstanceOf(TransactionMeta::class, $transactionA->getResultMeta());
@@ -449,8 +410,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_fee_meta_xdr()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
         $expected = 'AAAAAgAAAAMAFmnrAAAAAAAAAAC9XAVPf6tKVlcjG5EOEmcY0rWGZQaBHsjPUWzoyLzI+AAAAAA8M2CAABZp6wAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAFm8EAAAAAAAAAAC9XAVPf6tKVlcjG5EOEmcY0rWGZQaBHsjPUWzoyLzI+AAAAAA8M2AcABZp6wAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==';
 
         $this->assertEquals($expected, $transaction->getFeeMetaXdr());
@@ -462,8 +422,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_decoded_fee_meta()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction'));
-        $transactionA = TransactionResource::fromResource($resource);
+        $transactionA = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
         $transactionB = new TransactionResource();
 
         $this->assertInstanceOf(OperationMeta::class, $transactionA->getFeeMeta());
@@ -476,8 +435,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_memo()
     {
-        $resource = Resource::fromResponse(Response::fake('transaction_with_text_memo'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_text_memo'));
         $expected = '298424';
 
         $this->assertEquals($expected, $transaction->getMemo());
@@ -489,8 +447,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_memo_type()
     {
-        $resource = Resource::fromResponse(Response::fake('transaction_with_text_memo'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_text_memo'));
         $expected = 'text';
 
         $this->assertEquals($expected, $transaction->getMemoType());
@@ -502,8 +459,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_signatures()
     {
-        $resource = Resource::fromResponse(Response::fake('friendbot_transaction'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
         $expected = [
             "[signature1]",
             "[signature2]"
@@ -518,8 +474,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_preconditions()
     {
-        $resource = Resource::fromResponse(Response::fake('transaction_with_preconditions'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_preconditions'));
         $expected = [
             'time_bounds'                     => [
                 'min_time' => '1643673600',
@@ -547,8 +502,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_min_time_condition()
     {
-        $resource = Resource::fromResponse(Response::fake('transaction_with_preconditions'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_preconditions'));
         $expected = new \Datetime('@1643673600');
 
         $this->assertEquals($expected, $transaction->getMinTimeCondition());
@@ -560,8 +514,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_null_for_a_min_time_condition_of_zero()
     {
-        $resource = Resource::fromResponse(Response::fake('transaction_with_preconditions_alt'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_preconditions_alt'));
 
         $this->assertNull($transaction->getMinTimeCondition());
     }
@@ -572,8 +525,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_max_time_condition()
     {
-        $resource = Resource::fromResponse(Response::fake('transaction_with_preconditions'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_preconditions'));
         $expected = new \Datetime('@1643673600');
 
         $this->assertEquals($expected, $transaction->getMaxTimeCondition());
@@ -585,9 +537,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_null_for_a_max_time_condition_of_zero()
     {
-        $resource = Resource::fromResponse(Response::fake('transaction_with_preconditions_alt'));
-        $transaction = TransactionResource::fromResource($resource);
-
+        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_preconditions_alt'));
         $this->assertNull($transaction->getMaxTimeCondition());
     }
 
@@ -597,8 +547,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_min_ledger_condition()
     {
-        $resource = Resource::fromResponse(Response::fake('transaction_with_preconditions'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_preconditions'));
         $expected = 100;
 
         $this->assertEquals($expected, $transaction->getMinLedgerCondition());
@@ -610,8 +559,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_max_ledger_condition()
     {
-        $resource = Resource::fromResponse(Response::fake('transaction_with_preconditions'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_preconditions'));
         $expected = 200;
 
         $this->assertEquals($expected, $transaction->getMaxLedgerCondition());
@@ -623,8 +571,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_min_account_sequence_condition()
     {
-        $resource = Resource::fromResponse(Response::fake('transaction_with_preconditions'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_preconditions'));
         $expected = Int64::of('100');
 
         $this->assertEquals($expected, $transaction->getMinAccountSequenceCondition());
@@ -636,8 +583,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_min_account_sequence_age_condition()
     {
-        $resource = Resource::fromResponse(Response::fake('transaction_with_preconditions'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_preconditions'));
         $expected = UInt64::of('200');
 
         $this->assertTrue($expected->isEqualTo($transaction->getMinAccountSequenceAgeCondition()));
@@ -649,8 +595,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_null_for_a_missing_min_account_sequence_age_condition()
     {
-        $resource = Resource::fromResponse(Response::fake('transaction_with_preconditions_alt'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_preconditions_alt'));
 
         $this->assertNull($transaction->getMinAccountSequenceAgeCondition());
     }
@@ -661,8 +606,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_min_account_sequence_ledger_gap_condition()
     {
-        $resource = Resource::fromResponse(Response::fake('transaction_with_preconditions'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_preconditions'));
         $expected = 1;
 
         $this->assertEquals($expected, $transaction->getMinAccountSequenceLedgerGapCondition());
@@ -674,8 +618,7 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_extra_signers_condition()
     {
-        $resource = Resource::fromResponse(Response::fake('transaction_with_preconditions'));
-        $transaction = TransactionResource::fromResource($resource);
+        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_preconditions'));
         $expected = [
             'SIGNERA',
             'SIGNERB',

--- a/tests/Horizon/TransactionResourceTest.php
+++ b/tests/Horizon/TransactionResourceTest.php
@@ -32,40 +32,6 @@ class TransactionResourceTest extends TestCase
 {
     /**
      * @test
-     * @covers ::getLinks
-     */
-    public function it_returns_the_links_array()
-    {
-        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
-        $links = $transaction->getLinks();
-        $expected = [
-            'self'        => 'https://horizon-testnet.stellar.org/transactions/[hash]',
-            'account'     => 'https://horizon-testnet.stellar.org/accounts/[address]',
-            'ledger'      => 'https://horizon-testnet.stellar.org/ledgers/994571',
-            'operations'  => 'https://horizon-testnet.stellar.org/transactions/[hash]/operations{?cursor,limit,order}',
-            'effects'     => 'https://horizon-testnet.stellar.org/transactions/[hash]/effects{?cursor,limit,order}',
-            'precedes'    => 'https://horizon-testnet.stellar.org/transactions?order=asc&cursor=4271649918558208',
-            'succeeds'    => 'https://horizon-testnet.stellar.org/transactions?order=desc&cursor=4271649918558208',
-            'transaction' => 'https://horizon-testnet.stellar.org/transactions/[hash]',
-        ];
-
-        $this->assertEquals($expected, $links);
-    }
-
-    /**
-     * @test
-     * @covers ::getLink
-     */
-    public function it_returns_a_single_link_from_the_links_array()
-    {
-        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
-        $expected = 'https://horizon-testnet.stellar.org/transactions/[hash]';
-
-        $this->assertEquals($expected, $transaction->getLink('self'));
-    }
-
-    /**
-     * @test
      * @covers ::getSelfLink
      */
     public function it_returns_the_self_link()

--- a/tests/Horizon/stubs/account_transactions.json
+++ b/tests/Horizon/stubs/account_transactions.json
@@ -1,0 +1,133 @@
+{
+    "_links": {
+        "self": {
+            "href": "https://horizon-testnet.stellar.org/accounts/GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW/transactions?cursor=\u0026limit=10\u0026order=asc"
+        },
+        "next": {
+            "href": "https://horizon-testnet.stellar.org/accounts/GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW/transactions?cursor=1116579827830784\u0026limit=10\u0026order=asc"
+        },
+        "prev": {
+            "href": "https://horizon-testnet.stellar.org/accounts/GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW/transactions?cursor=1115351467184128\u0026limit=10\u0026order=desc"
+        }
+    },
+    "_embedded": {
+        "records": [
+            {
+                "_links": {
+                    "self": {
+                        "href": "https://horizon-testnet.stellar.org/transactions/4d69f895d74363ba6599d4394672d6c93ef529fcc3dc6610f977f55760ded2c4"
+                    },
+                    "account": {
+                        "href": "https://horizon-testnet.stellar.org/accounts/GA5R5LJDMYRP5WAUROYC3RRKMHP65Z3FVFIVZ5GODTTXTIVJB5THHRAK"
+                    },
+                    "ledger": {
+                        "href": "https://horizon-testnet.stellar.org/ledgers/259688"
+                    },
+                    "operations": {
+                        "href": "https://horizon-testnet.stellar.org/transactions/4d69f895d74363ba6599d4394672d6c93ef529fcc3dc6610f977f55760ded2c4/operations{?cursor,limit,order}",
+                        "templated": true
+                    },
+                    "effects": {
+                        "href": "https://horizon-testnet.stellar.org/transactions/4d69f895d74363ba6599d4394672d6c93ef529fcc3dc6610f977f55760ded2c4/effects{?cursor,limit,order}",
+                        "templated": true
+                    },
+                    "precedes": {
+                        "href": "https://horizon-testnet.stellar.org/transactions?order=asc\u0026cursor=1115351467184128"
+                    },
+                    "succeeds": {
+                        "href": "https://horizon-testnet.stellar.org/transactions?order=desc\u0026cursor=1115351467184128"
+                    },
+                    "transaction": {
+                        "href": "https://horizon-testnet.stellar.org/transactions/4d69f895d74363ba6599d4394672d6c93ef529fcc3dc6610f977f55760ded2c4"
+                    }
+                },
+                "id": "4d69f895d74363ba6599d4394672d6c93ef529fcc3dc6610f977f55760ded2c4",
+                "paging_token": "1115351467184128",
+                "successful": true,
+                "hash": "4d69f895d74363ba6599d4394672d6c93ef529fcc3dc6610f977f55760ded2c4",
+                "ledger": 259688,
+                "created_at": "2022-12-30T04:19:30Z",
+                "source_account": "GA5R5LJDMYRP5WAUROYC3RRKMHP65Z3FVFIVZ5GODTTXTIVJB5THHRAK",
+                "source_account_sequence": "1498943586379",
+                "fee_account": "GA5R5LJDMYRP5WAUROYC3RRKMHP65Z3FVFIVZ5GODTTXTIVJB5THHRAK",
+                "fee_charged": "100",
+                "max_fee": "1000000",
+                "operation_count": 1,
+                "envelope_xdr": "AAAAAgAAAAA7Hq0jZiL+2BSLsC3GKmHf7udlqVFc9M4c53miqQ9mcwAPQkAAAAFdAAAASwAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAABAAAAABB90WssODNIgi6BHveqzxTRmIpvAFRyVNM+Hm2GVuCcAAAAAAAAAAAn0OqXx24CHzYkbvF1x6Hpb1/8xt0RBQKXblqyRrbgZQAAABdIdugAAAAAAAAAAAKpD2ZzAAAAQEr0smRfuGPrdfh+sGubfFn5RHlaeO55H9TeUv0CVhe36fSTqwhfjzef9XEQpbJbfbDLRcS4ivnMr4iX4RLeIQaGVuCcAAAAQBK57IiDxLyzM1vTTYs9m76X2OXkmkr7JHcrRYAxGWGVaF0lv3zTs22oH/jMWXiFvkMjEnb4uZgda2BcHrTLzwU=",
+                "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
+                "result_meta_xdr": "AAAAAgAAAAIAAAADAAP2aAAAAAAAAAAAOx6tI2Yi/tgUi7Atxiph3+7nZalRXPTOHOd5oqkPZnMAAAAAPBNOvAAAAV0AAABKAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAwAAAAAAA+OtAAAAAGOuBIoAAAAAAAAAAQAD9mgAAAAAAAAAADserSNmIv7YFIuwLcYqYd/u52WpUVz0zhzneaKpD2ZzAAAAADwTTrwAAAFdAAAASwAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAMAAAAAAAP2aAAAAABjrmbSAAAAAAAAAAEAAAADAAAAAwAD9mYAAAAAAAAAABB90WssODNIgi6BHveqzxTRmIpvAFRyVNM+Hm2GVuCcATAwvLnU6GAAAADhAAAAZAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAMAAAAAAAABhgAAAABjmZxhAAAAAAAAAAEAA/ZoAAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAEwMKVxXgBgAAAA4QAAAGQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAADAAAAAAAAAYYAAAAAY5mcYQAAAAAAAAAAAAP2aAAAAAAAAAAAJ9Dql8duAh82JG7xdceh6W9f/MbdEQUCl25aska24GUAAAAXSHboAAAD9mgAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "fee_meta_xdr": "AAAAAgAAAAMAA+OtAAAAAAAAAAA7Hq0jZiL+2BSLsC3GKmHf7udlqVFc9M4c53miqQ9mcwAAAAA8E08gAAABXQAAAEoAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAADAAAAAAAD460AAAAAY64EigAAAAAAAAABAAP2aAAAAAAAAAAAOx6tI2Yi/tgUi7Atxiph3+7nZalRXPTOHOd5oqkPZnMAAAAAPBNOvAAAAV0AAABKAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAwAAAAAAA+OtAAAAAGOuBIoAAAAA",
+                "memo_type": "none",
+                "signatures": [
+                    "SvSyZF+4Y+t1+H6wa5t8WflEeVp47nkf1N5S/QJWF7fp9JOrCF+PN5/1cRClslt9sMtFxLiK+cyviJfhEt4hBg==",
+                    "ErnsiIPEvLMzW9NNiz2bvpfY5eSaSvskdytFgDEZYZVoXSW/fNOzbagf+MxZeIW+QyMSdvi5mB1rYFwetMvPBQ=="
+                ],
+                "valid_after": "1970-01-01T00:00:00Z",
+                "preconditions": {
+                    "timebounds": {
+                        "min_time": "0"
+                    }
+                }
+            },
+            {
+                "_links": {
+                    "self": {
+                        "href": "https://horizon-testnet.stellar.org/transactions/8aa8eb2a3f0d9023484c2ae27a477d36779865d9b40e46d3609c63f60398a963"
+                    },
+                    "account": {
+                        "href": "https://horizon-testnet.stellar.org/accounts/GAGT75DARTXIN25E6HRJIPDQPXFEB5OFWEAH7AN6WNBXQKDJCP6ZWRRB"
+                    },
+                    "ledger": {
+                        "href": "https://horizon-testnet.stellar.org/ledgers/259974"
+                    },
+                    "operations": {
+                        "href": "https://horizon-testnet.stellar.org/transactions/8aa8eb2a3f0d9023484c2ae27a477d36779865d9b40e46d3609c63f60398a963/operations{?cursor,limit,order}",
+                        "templated": true
+                    },
+                    "effects": {
+                        "href": "https://horizon-testnet.stellar.org/transactions/8aa8eb2a3f0d9023484c2ae27a477d36779865d9b40e46d3609c63f60398a963/effects{?cursor,limit,order}",
+                        "templated": true
+                    },
+                    "precedes": {
+                        "href": "https://horizon-testnet.stellar.org/transactions?order=asc\u0026cursor=1116579827830784"
+                    },
+                    "succeeds": {
+                        "href": "https://horizon-testnet.stellar.org/transactions?order=desc\u0026cursor=1116579827830784"
+                    },
+                    "transaction": {
+                        "href": "https://horizon-testnet.stellar.org/transactions/8aa8eb2a3f0d9023484c2ae27a477d36779865d9b40e46d3609c63f60398a963"
+                    }
+                },
+                "id": "8aa8eb2a3f0d9023484c2ae27a477d36779865d9b40e46d3609c63f60398a963",
+                "paging_token": "1116579827830784",
+                "successful": true,
+                "hash": "8aa8eb2a3f0d9023484c2ae27a477d36779865d9b40e46d3609c63f60398a963",
+                "ledger": 259974,
+                "created_at": "2022-12-30T04:44:35Z",
+                "source_account": "GAGT75DARTXIN25E6HRJIPDQPXFEB5OFWEAH7AN6WNBXQKDJCP6ZWRRB",
+                "source_account_sequence": "1115312812457985",
+                "fee_account": "GAGT75DARTXIN25E6HRJIPDQPXFEB5OFWEAH7AN6WNBXQKDJCP6ZWRRB",
+                "fee_charged": "300",
+                "max_fee": "300",
+                "operation_count": 3,
+                "envelope_xdr": "AAAAAgAAAAANP/RgjO6G66Tx4pQ8cH3KQPXFsQB/gb6zQ3goaRP9mwAAASwAA/ZfAAAAAQAAAAIAAAABAAAAAGOubHQAAAAAY656wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAQAAAAANP/RgjO6G66Tx4pQ8cH3KQPXFsQB/gb6zQ3goaRP9mwAAAAoAAAAIaXBmc2hhc2gAAAABAAAAO2JhZmtyZWlkcXBxdnFlN3Z6bHRqMnUzdXJybGs2dnBydHE3dW83N3FjdjR4eTJ3ZHZ1YmN2MjJrMnZ5AAAAAAEAAAAAJ9Dql8duAh82JG7xdceh6W9f/MbdEQUCl25aska24GUAAAAGAAAAAlNSTE5GVAAAAAAAAAAAAAANP/RgjO6G66Tx4pQ8cH3KQPXFsQB/gb6zQ3goaRP9mwAAAAAAAAABAAAAAQAAAAANP/RgjO6G66Tx4pQ8cH3KQPXFsQB/gb6zQ3goaRP9mwAAAAEAAAAAJ9Dql8duAh82JG7xdceh6W9f/MbdEQUCl25aska24GUAAAACU1JMTkZUAAAAAAAAAAAAAA0/9GCM7obrpPHilDxwfcpA9cWxAH+BvrNDeChpE/2bAAAAAAAAAAEAAAAAAAAAAka24GUAAABAWnW54TP0DcqrT4VqhUSjBj+F7f6AKGLOMMDrfz05tGLUl80echAPR9AhYJjeD2g8jeDUVDcJ0EWmoUwGwgLHDGkT/ZsAAABALCOMtdnMkql5j3zhdb2lj3hjg7+51V0LyqdvWk11NKed8LhSL4fUbH3aQOj01gT1n9Tqa9EkPtwH8ricvFQABA==",
+                "result_xdr": "AAAAAAAAASwAAAAAAAAAAwAAAAAAAAAKAAAAAAAAAAAAAAAGAAAAAAAAAAAAAAABAAAAAAAAAAA=",
+                "result_meta_xdr": "AAAAAgAAAAIAAAADAAP3hgAAAAAAAAAADT/0YIzuhuuk8eKUPHB9ykD1xbEAf4G+s0N4KGkT/ZsAAAAXSHbm1AAD9l8AAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAP3hgAAAAAAAAAADT/0YIzuhuuk8eKUPHB9ykD1xbEAf4G+s0N4KGkT/ZsAAAAXSHbm1AAD9l8AAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAwAAAAAAA/eGAAAAAGOubLMAAAAAAAAAAwAAAAMAAAAAAAP3hgAAAAMAAAAADT/0YIzuhuuk8eKUPHB9ykD1xbEAf4G+s0N4KGkT/ZsAAAAIaXBmc2hhc2gAAAA7YmFma3JlaWRxcHF2cWU3dnpsdGoydTN1cnJsazZ2cHJ0cTd1bzc3cWN2NHh5MndkdnViY3YyMmsydnkAAAAAAAAAAAAAAAADAAP3hgAAAAAAAAAADT/0YIzuhuuk8eKUPHB9ykD1xbEAf4G+s0N4KGkT/ZsAAAAXSHbm1AAD9l8AAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAwAAAAAAA/eGAAAAAGOubLMAAAAAAAAAAQAD94YAAAAAAAAAAA0/9GCM7obrpPHilDxwfcpA9cWxAH+BvrNDeChpE/2bAAAAF0h25tQAA/ZfAAAAAQAAAAEAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAMAAAAAAAP3hgAAAABjrmyzAAAAAAAAAAMAAAAAAAP3hgAAAAEAAAAAJ9Dql8duAh82JG7xdceh6W9f/MbdEQUCl25aska24GUAAAACU1JMTkZUAAAAAAAAAAAAAA0/9GCM7obrpPHilDxwfcpA9cWxAH+BvrNDeChpE/2bAAAAAAAAAAAAAAAAAAAAAQAAAAEAAAAAAAAAAAAAAAMAA/ZoAAAAAAAAAAAn0OqXx24CHzYkbvF1x6Hpb1/8xt0RBQKXblqyRrbgZQAAABdIdugAAAP2aAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAA/eGAAAAAAAAAAAn0OqXx24CHzYkbvF1x6Hpb1/8xt0RBQKXblqyRrbgZQAAABdIdugAAAP2aAAAAAAAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAIAAAADAAP3hgAAAAEAAAAAJ9Dql8duAh82JG7xdceh6W9f/MbdEQUCl25aska24GUAAAACU1JMTkZUAAAAAAAAAAAAAA0/9GCM7obrpPHilDxwfcpA9cWxAH+BvrNDeChpE/2bAAAAAAAAAAAAAAAAAAAAAQAAAAEAAAAAAAAAAAAAAAEAA/eGAAAAAQAAAAAn0OqXx24CHzYkbvF1x6Hpb1/8xt0RBQKXblqyRrbgZQAAAAJTUkxORlQAAAAAAAAAAAAADT/0YIzuhuuk8eKUPHB9ykD1xbEAf4G+s0N4KGkT/ZsAAAAAAAAAAQAAAAAAAAABAAAAAQAAAAAAAAAAAAAAAA==",
+                "fee_meta_xdr": "AAAAAgAAAAMAA/ZfAAAAAAAAAAANP/RgjO6G66Tx4pQ8cH3KQPXFsQB/gb6zQ3goaRP9mwAAABdIdugAAAP2XwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAA/eGAAAAAAAAAAANP/RgjO6G66Tx4pQ8cH3KQPXFsQB/gb6zQ3goaRP9mwAAABdIdubUAAP2XwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+                "memo_type": "none",
+                "signatures": [
+                    "WnW54TP0DcqrT4VqhUSjBj+F7f6AKGLOMMDrfz05tGLUl80echAPR9AhYJjeD2g8jeDUVDcJ0EWmoUwGwgLHDA==",
+                    "LCOMtdnMkql5j3zhdb2lj3hjg7+51V0LyqdvWk11NKed8LhSL4fUbH3aQOj01gT1n9Tqa9EkPtwH8ricvFQABA=="
+                ],
+                "valid_after": "2022-12-30T04:43:32Z",
+                "valid_before": "2022-12-30T05:44:32Z",
+                "preconditions": {
+                    "timebounds": {
+                        "min_time": "1672375412",
+                        "max_time": "1672379072"
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/tests/Utility/UrlTest.php
+++ b/tests/Utility/UrlTest.php
@@ -12,7 +12,7 @@ use StageRightLabs\Bloom\Utility\Url;
  */
 class UrlTest extends TestCase
 {
-    public const EXAMPLE = 'https://developer.mozilla.org/en-US/search?q=URL';
+    public const EXAMPLE = 'https://developer.mozilla.org/en-US/search?q=URL&r=1';
     public const EXAMPLE_WITH_PORT = 'https://developer.mozilla.org:80/en-US/search?q=URL';
 
     /**
@@ -49,12 +49,27 @@ class UrlTest extends TestCase
 
     /**
      * @test
-     * @covers ::query
+     * @covers ::parameters
      */
     public function it_returns_the_query_string_parameters_as_an_array()
     {
-        $this->assertEquals(['q' => 'URL'], Url::query(self::EXAMPLE));
-        $this->assertEquals([], Url::query(''));
+        $expected = [
+            'q' => 'URL',
+            'r' => '1'
+        ];
+        $this->assertEquals($expected, Url::parameters(self::EXAMPLE));
+        $this->assertEquals([], Url::parameters(''));
+    }
+
+    /**
+     * @test
+     * @covers ::parameter
+     */
+    public function it_returns_a_single_query_string_parameter()
+    {
+        $this->assertEquals('URL', Url::parameter(self::EXAMPLE, 'q'));
+        $this->assertEquals('1', Url::parameter(self::EXAMPLE, 'r'));
+        $this->assertNull(Url::parameter(self::EXAMPLE, 'foo'));
     }
 
     /**

--- a/tests/Utility/UrlTest.php
+++ b/tests/Utility/UrlTest.php
@@ -101,4 +101,20 @@ class UrlTest extends TestCase
             ['foo' => 'bar']
         ));
     }
+
+    /**
+     * @test
+     * @covers ::build
+     */
+    public function it_converts_booleans_to_strings_in_url_query_parameters()
+    {
+        $params = [
+            'foo' => true,
+            'bar' => false,
+            'baz' => null,
+        ];
+        $url = Url::build('http://example.com', 'path', $params);
+
+        $this->assertEquals('http://example.com/path?foo=true&bar=false', $url);
+    }
 }


### PR DESCRIPTION
Resource collections are classes that represent groups of identical Json resources, as returned by Horizon.  The `ResourceCollection` class has helper methods for extracting pagination information to facilitate requesting additional pages of data from Horizon.  

This PR adds the `ResourceCollection` base class which can then be extended by covariant classes that represent specific types of resource collections.

Additionally this PR makes some adjustments to the URL utility methods dealing with query parameters, and adds a `transactions` method to the AccountService for fetching paginated account transaction data.