### PR TITLE
Simplify the structure of Resource classes

### DIFF
--- a/src/Horizon/AccountResource.php
+++ b/src/Horizon/AccountResource.php
@@ -391,7 +391,7 @@ class AccountResource extends Resource
     {
         if ($balances = $this->payload->getArray('balances')) {
             return array_map(function ($balance) {
-                return AccountBalanceResource::fromArray($balance);
+                return AccountBalanceResource::wrap($balance);
             }, $balances);
         }
 
@@ -413,7 +413,7 @@ class AccountResource extends Resource
         if ($balances = $this->payload->getArray('balances')) {
             foreach ($balances as $balance) {
                 if ($balance['asset_type'] == 'native' && $asset->isNative()) {
-                    return AccountBalanceResource::fromArray($balance);
+                    return AccountBalanceResource::wrap($balance);
                 }
 
                 if (
@@ -421,7 +421,7 @@ class AccountResource extends Resource
                     && $asset->getAssetCode() == $balance['asset_code']
                     && $asset->getIssuerAddress() == $balance['asset_issuer']
                 ) {
-                    return AccountBalanceResource::fromArray($balance);
+                    return AccountBalanceResource::wrap($balance);
                 }
             }
         }
@@ -439,7 +439,7 @@ class AccountResource extends Resource
     {
         if ($signers = $this->payload->getArray('signers')) {
             return array_map(function ($signer) {
-                return AccountSignerResource::fromArray($signer);
+                return AccountSignerResource::wrap($signer);
             }, $signers);
         }
 

--- a/src/Horizon/Error.php
+++ b/src/Horizon/Error.php
@@ -249,7 +249,9 @@ final class Error
     ];
 
     /**
-     * A sanity check for the API consumer: Did the request fail?
+     * A Horizon request will return an error or a resource/response. If given
+     * an error then the request was not successful. This mirrors a similar
+     * function on the Horizon/Resource class that returns false.
      *
      * @return bool
      */

--- a/src/Horizon/TransactionResourceCollection.php
+++ b/src/Horizon/TransactionResourceCollection.php
@@ -14,7 +14,7 @@ class TransactionResourceCollection extends ResourceCollection
      *
      * @return class-string
      */
-    protected function getResourceClass(): string
+    protected static function getResourceClass(): string
     {
         return TransactionResource::class;
     }

--- a/tests/Horizon/AccountBalanceResourceTest.php
+++ b/tests/Horizon/AccountBalanceResourceTest.php
@@ -41,7 +41,7 @@ class AccountBalanceResourceTest extends TestCase
      */
     public function it_returns_the_balance_as_a_string()
     {
-        $resource = AccountBalanceResource::fromArray(self::XLM_BALANCE_EXAMPLE);
+        $resource = AccountBalanceResource::wrap(self::XLM_BALANCE_EXAMPLE);
         $this->assertEquals('198.8944970', $resource->getBalance());
     }
 
@@ -51,7 +51,7 @@ class AccountBalanceResourceTest extends TestCase
      */
     public function it_returns_the_balance_as_an_int64()
     {
-        $resource = AccountBalanceResource::fromArray(self::XLM_BALANCE_EXAMPLE);
+        $resource = AccountBalanceResource::wrap(self::XLM_BALANCE_EXAMPLE);
         $this->assertInstanceOf(Int64::class, $resource->getDescaledBalance());
         $this->assertTrue($resource->getDescaledBalance()->isEqualTo('1988944970'));
     }
@@ -63,7 +63,7 @@ class AccountBalanceResourceTest extends TestCase
      */
     public function the_default_balance_is_zero()
     {
-        $resource = AccountBalanceResource::fromArray([]);
+        $resource = AccountBalanceResource::wrap([]);
         $this->assertEquals('0', $resource->getBalance());
         $this->assertTrue($resource->getDescaledBalance()->isEqualTo('0'));
     }
@@ -74,7 +74,7 @@ class AccountBalanceResourceTest extends TestCase
      */
     public function it_returns_the_buying_liabilities_as_a_scaled_amount()
     {
-        $resource = AccountBalanceResource::fromArray(self::PHP_BALANCE_EXAMPLE);
+        $resource = AccountBalanceResource::wrap(self::PHP_BALANCE_EXAMPLE);
         $this->assertInstanceOf(ScaledAmount::class, $resource->getBuyingLiabilities());
         $this->assertEquals('100.0000000', $resource->getBuyingLiabilities()->toNativeString());
     }
@@ -85,7 +85,7 @@ class AccountBalanceResourceTest extends TestCase
      */
     public function it_returns_the_buying_liabilities_as_an_int64()
     {
-        $resource = AccountBalanceResource::fromArray(self::PHP_BALANCE_EXAMPLE);
+        $resource = AccountBalanceResource::wrap(self::PHP_BALANCE_EXAMPLE);
         $this->assertInstanceOf(Int64::class, $resource->getDescaledBuyingLiabilities());
         $this->assertEquals('1000000000', $resource->getDescaledBuyingLiabilities()->toNativeString());
     }
@@ -97,7 +97,7 @@ class AccountBalanceResourceTest extends TestCase
      */
     public function the_default_buying_liabilities_value_is_zero()
     {
-        $resource = AccountBalanceResource::fromArray([]);
+        $resource = AccountBalanceResource::wrap([]);
         $this->assertEquals('0', $resource->getBuyingLiabilities());
         $this->assertTrue($resource->getDescaledBuyingLiabilities()->isEqualTo('0'));
     }
@@ -108,7 +108,7 @@ class AccountBalanceResourceTest extends TestCase
      */
     public function it_returns_the_selling_liabilities_as_a_scaled_amount()
     {
-        $resource = AccountBalanceResource::fromArray(self::PHP_BALANCE_EXAMPLE);
+        $resource = AccountBalanceResource::wrap(self::PHP_BALANCE_EXAMPLE);
         $this->assertEquals('200.0000000', $resource->getSellingLiabilities());
     }
 
@@ -118,7 +118,7 @@ class AccountBalanceResourceTest extends TestCase
      */
     public function it_returns_the_descaled_selling_liabilities_as_an_int64()
     {
-        $resource = AccountBalanceResource::fromArray(self::PHP_BALANCE_EXAMPLE);
+        $resource = AccountBalanceResource::wrap(self::PHP_BALANCE_EXAMPLE);
         $this->assertInstanceOf(Int64::class, $resource->getDescaledSellingLiabilities());
         $this->assertEquals('2000000000', $resource->getDescaledSellingLiabilities()->toNativeString());
     }
@@ -130,7 +130,7 @@ class AccountBalanceResourceTest extends TestCase
      */
     public function the_default_selling_liabilities_value_is_zero()
     {
-        $resource = AccountBalanceResource::fromArray([]);
+        $resource = AccountBalanceResource::wrap([]);
         $this->assertEquals('0.0000000', $resource->getSellingLiabilities()->toNativeString());
         $this->assertTrue($resource->getDescaledSellingLiabilities()->isEqualTo('0'));
     }
@@ -141,7 +141,7 @@ class AccountBalanceResourceTest extends TestCase
      */
     public function it_returns_the_limit_as_a_scaled_amount()
     {
-        $resource = AccountBalanceResource::fromArray(self::PHP_BALANCE_EXAMPLE);
+        $resource = AccountBalanceResource::wrap(self::PHP_BALANCE_EXAMPLE);
         $this->assertInstanceOf(ScaledAmount::class, $resource->getLimit());
         $this->assertEquals('12345678.0000000', $resource->getLimit()->toNativeString());
     }
@@ -152,7 +152,7 @@ class AccountBalanceResourceTest extends TestCase
      */
     public function it_returns_the_limit_as_an_int64()
     {
-        $resource = AccountBalanceResource::fromArray(self::PHP_BALANCE_EXAMPLE);
+        $resource = AccountBalanceResource::wrap(self::PHP_BALANCE_EXAMPLE);
         $this->assertInstanceOf(Int64::class, $resource->getDescaledLimit());
         $this->assertEquals('123456780000000', $resource->getDescaledLimit()->toNativeString());
     }
@@ -164,7 +164,7 @@ class AccountBalanceResourceTest extends TestCase
      */
     public function it_provides_a_default_limit()
     {
-        $resource = AccountBalanceResource::fromArray([]);
+        $resource = AccountBalanceResource::wrap([]);
         $this->assertEquals('922337203685.4775807', $resource->getLimit()->toNativeString());
         $this->assertEquals('9223372036854775807', $resource->getDescaledLimit()->toNativeString());
     }
@@ -175,9 +175,9 @@ class AccountBalanceResourceTest extends TestCase
      */
     public function it_returns_the_asset_type()
     {
-        $resourceA = AccountBalanceResource::fromArray(self::PHP_BALANCE_EXAMPLE);
-        $resourceB = AccountBalanceResource::fromArray(self::XLM_BALANCE_EXAMPLE);
-        $resourceC = AccountBalanceResource::fromArray([]);
+        $resourceA = AccountBalanceResource::wrap(self::PHP_BALANCE_EXAMPLE);
+        $resourceB = AccountBalanceResource::wrap(self::XLM_BALANCE_EXAMPLE);
+        $resourceC = AccountBalanceResource::wrap([]);
 
         $this->assertEquals('credit_alphanum4', $resourceA->getAssetType());
         $this->assertEquals('native', $resourceB->getAssetType());
@@ -190,8 +190,8 @@ class AccountBalanceResourceTest extends TestCase
      */
     public function it_knows_if_it_represents_the_native_asset()
     {
-        $resourceA = AccountBalanceResource::fromArray(self::PHP_BALANCE_EXAMPLE);
-        $resourceB = AccountBalanceResource::fromArray(self::XLM_BALANCE_EXAMPLE);
+        $resourceA = AccountBalanceResource::wrap(self::PHP_BALANCE_EXAMPLE);
+        $resourceB = AccountBalanceResource::wrap(self::XLM_BALANCE_EXAMPLE);
 
         $this->assertFalse($resourceA->isNativeAsset());
         $this->assertTrue($resourceB->isNativeAsset());
@@ -203,9 +203,9 @@ class AccountBalanceResourceTest extends TestCase
      */
     public function it_returns_the_asset_code_if_present()
     {
-        $resourceA = AccountBalanceResource::fromArray(self::PHP_BALANCE_EXAMPLE);
-        $resourceB = AccountBalanceResource::fromArray(self::XLM_BALANCE_EXAMPLE);
-        $resourceC = AccountBalanceResource::fromArray([]);
+        $resourceA = AccountBalanceResource::wrap(self::PHP_BALANCE_EXAMPLE);
+        $resourceB = AccountBalanceResource::wrap(self::XLM_BALANCE_EXAMPLE);
+        $resourceC = AccountBalanceResource::wrap([]);
 
         $this->assertEquals('PHP', $resourceA->getAssetCode());
         $this->assertEquals('XLM', $resourceB->getAssetCode());
@@ -218,9 +218,9 @@ class AccountBalanceResourceTest extends TestCase
      */
     public function it_returns_the_asset_issuer_if_present()
     {
-        $resourceA = AccountBalanceResource::fromArray(self::PHP_BALANCE_EXAMPLE);
-        $resourceB = AccountBalanceResource::fromArray(self::XLM_BALANCE_EXAMPLE);
-        $resourceC = AccountBalanceResource::fromArray([]);
+        $resourceA = AccountBalanceResource::wrap(self::PHP_BALANCE_EXAMPLE);
+        $resourceB = AccountBalanceResource::wrap(self::XLM_BALANCE_EXAMPLE);
+        $resourceC = AccountBalanceResource::wrap([]);
 
         $this->assertEquals('GBUQWP3BOUZX34TOND2QV7QQ7K7VJTG6VSE7WMLBTMDJLLAW7YKGU6EP', $resourceA->getAssetIssuer());
         $this->assertNull($resourceB->getAssetIssuer());
@@ -233,9 +233,9 @@ class AccountBalanceResourceTest extends TestCase
      */
     public function it_returns_the_sponsor_if_present()
     {
-        $resourceA = AccountBalanceResource::fromArray(self::PHP_BALANCE_EXAMPLE);
-        $resourceB = AccountBalanceResource::fromArray(self::XLM_BALANCE_EXAMPLE);
-        $resourceC = AccountBalanceResource::fromArray([]);
+        $resourceA = AccountBalanceResource::wrap(self::PHP_BALANCE_EXAMPLE);
+        $resourceB = AccountBalanceResource::wrap(self::XLM_BALANCE_EXAMPLE);
+        $resourceC = AccountBalanceResource::wrap([]);
 
         $this->assertEquals('GBUQWP3BOUZX34TOND2QV7QQ7K7VJTG6VSE7WMLBTMDJLLAW7YKGU6EP', $resourceA->getSponsor());
         $this->assertNull($resourceB->getSponsor());
@@ -248,9 +248,9 @@ class AccountBalanceResourceTest extends TestCase
      */
     public function it_returns_an_asset_identifier()
     {
-        $resourceA = AccountBalanceResource::fromArray(self::PHP_BALANCE_EXAMPLE);
-        $resourceB = AccountBalanceResource::fromArray(self::XLM_BALANCE_EXAMPLE);
-        $resourceC = AccountBalanceResource::fromArray([]);
+        $resourceA = AccountBalanceResource::wrap(self::PHP_BALANCE_EXAMPLE);
+        $resourceB = AccountBalanceResource::wrap(self::XLM_BALANCE_EXAMPLE);
+        $resourceC = AccountBalanceResource::wrap([]);
 
         $this->assertEquals('PHP:GBUQWP3BOUZX34TOND2QV7QQ7K7VJTG6VSE7WMLBTMDJLLAW7YKGU6EP', $resourceA->getCanonicalAssetName());
         $this->assertEquals('native', $resourceB->getCanonicalAssetName());

--- a/tests/Horizon/AccountResourceTest.php
+++ b/tests/Horizon/AccountResourceTest.php
@@ -25,7 +25,9 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_links_array()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
         $links = $account->getLinks();
         $expected = [
             'self'         => 'https://horizon-testnet.stellar.org/accounts/[address]',
@@ -47,7 +49,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_a_single_link()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
+
         $this->assertEquals('https://horizon-testnet.stellar.org/accounts/[address]', $account->getLink('self'));
     }
 
@@ -57,7 +62,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_self_link()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
+
         $this->assertEquals('https://horizon-testnet.stellar.org/accounts/[address]', $account->getSelfLink());
     }
 
@@ -67,7 +75,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_transactions_link()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
+
         $this->assertEquals('https://horizon-testnet.stellar.org/accounts/[address]/transactions{?cursor,limit,order}', $account->getTransactionsLink());
     }
 
@@ -77,7 +88,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_operations_link()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
+
         $this->assertEquals('https://horizon-testnet.stellar.org/accounts/[address]/operations{?cursor,limit,order}', $account->getOperationsLink());
     }
 
@@ -87,7 +101,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_payments_link()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
+
         $this->assertEquals('https://horizon-testnet.stellar.org/accounts/[address]/payments{?cursor,limit,order}', $account->getPaymentsLink());
     }
 
@@ -97,7 +114,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_effects_link()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
+
         $this->assertEquals('https://horizon-testnet.stellar.org/accounts/[address]/effects{?cursor,limit,order}', $account->getEffectsLink());
     }
 
@@ -107,7 +127,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_offers_link()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
+
         $this->assertEquals('https://horizon-testnet.stellar.org/accounts/[address]/offers{?cursor,limit,order}', $account->getOffersLink());
     }
 
@@ -117,7 +140,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_trades_link()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
+
         $this->assertEquals('https://horizon-testnet.stellar.org/accounts/[address]/trades{?cursor,limit,order}', $account->getTradesLink());
     }
 
@@ -127,7 +153,9 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_data_link()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
         $this->assertEquals('https://horizon-testnet.stellar.org/accounts/[address]/data/{key}', $account->getDataLink());
     }
 
@@ -137,7 +165,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_account_identifier()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
+
         $this->assertEquals('[address]', $account->getId());
     }
 
@@ -147,9 +178,11 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_an_account_id()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account', [
-            'address' => 'GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW'
-        ]));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account', [
+                'address' => 'GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW'
+            ])->getBody()
+        );
 
         $this->assertInstanceOf(AccountId::class, $account->getAccountId());
         $this->assertEquals(
@@ -164,9 +197,11 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_missing_account_id()
     {
-        $account = AccountResource::fromResponse(Response::fake('account_without_data', [
-            'address' => 'GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW'
-        ]));
+        $account = AccountResource::wrap(
+            Response::fake('account_without_data', [
+                'address' => 'GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW'
+            ])->getBody()
+        );
 
         $this->assertNull($account->getAccountId());
     }
@@ -177,7 +212,9 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_sequence_number()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
 
         $this->assertInstanceOf(SequenceNumber::class, $account->getSequenceNumber());
         $this->assertEquals('5607590906036224', $account->getSequenceNumber()->toNativeString());
@@ -189,7 +226,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_a_missing_sequence_number()
     {
-        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
+        $account = AccountResource::wrap(
+            Response::fake('account_without_data')->getBody()
+        );
+
         $this->assertNull($account->getSequenceNumber());
     }
 
@@ -199,7 +239,9 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_sequence_ledger()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
 
         $this->assertInstanceOf(UInt32::class, $account->getSequenceLedger());
         $this->assertEquals(50, $account->getSequenceLedger()->toNativeInt());
@@ -211,7 +253,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_a_missing_sequence_ledger()
     {
-        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
+        $account = AccountResource::wrap(
+            Response::fake('account_without_data')->getBody()
+        );
+
         $this->assertNull($account->getSequenceLedger());
     }
 
@@ -221,7 +266,9 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_sequence_time()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
 
         $this->assertInstanceOf(UInt64::class, $account->getSequenceTime());
         $this->assertEquals('100', $account->getSequenceTime()->toNativeString());
@@ -233,7 +280,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_missing_sequence_time()
     {
-        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
+        $account = AccountResource::wrap(
+            Response::fake('account_without_data')->getBody()
+        );
+
         $this->assertNull($account->getSequenceTime());
     }
 
@@ -243,7 +293,9 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_sub_entry_count()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
 
         $this->assertInstanceOf(UInt32::class, $account->getSubEntryCount());
         $this->assertEquals(10, $account->getSubEntryCount()->toNativeInt());
@@ -255,7 +307,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_a_missing_sub_entry_count()
     {
-        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
+        $account = AccountResource::wrap(
+            Response::fake('account_without_data')->getBody()
+        );
+
         $this->assertNull($account->getSubEntryCount());
     }
 
@@ -265,7 +320,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_home_domain()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
+
         $this->assertEquals('[domain]', $account->getHomeDomain());
     }
 
@@ -275,7 +333,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_a_missing_home_domain()
     {
-        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
+        $account = AccountResource::wrap(
+            Response::fake('account_without_data')->getBody()
+        );
+
         $this->assertNull($account->getHomeDomain());
     }
 
@@ -285,7 +346,9 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_last_modified_ledger_sequence()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
 
         $this->assertInstanceOf(UInt32::class, $account->getLastModifiedLedgerSequence());
         $this->assertEquals(1305619, $account->getLastModifiedLedgerSequence()->toNativeInt());
@@ -297,7 +360,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_missing_last_modified_ledger_sequence()
     {
-        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
+        $account = AccountResource::wrap(
+            Response::fake('account_without_data')->getBody()
+        );
+
         $this->assertNull($account->getLastModifiedLedgerSequence());
     }
 
@@ -307,7 +373,9 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_reserves_sponsoring_count()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
 
         $this->assertInstanceOf(UInt32::class, $account->getReservesSponsoringCount());
         $this->assertEquals(1, $account->getReservesSponsoringCount()->toNativeInt());
@@ -319,7 +387,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_missing_reserves_sponsoring_count()
     {
-        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
+        $account = AccountResource::wrap(
+            Response::fake('account_without_data')->getBody()
+        );
+
         $this->assertNull($account->getReservesSponsoringCount());
     }
 
@@ -329,7 +400,9 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_reserves_sponsored_count()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
 
         $this->assertInstanceOf(UInt32::class, $account->getReservesSponsoredCount());
         $this->assertEquals(2, $account->getReservesSponsoredCount()->toNativeInt());
@@ -341,7 +414,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_missing_reserves_sponsored_count()
     {
-        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
+        $account = AccountResource::wrap(
+            Response::fake('account_without_data')->getBody()
+        );
+
         $this->assertNull($account->getReservesSponsoredCount());
     }
 
@@ -351,7 +427,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_sponsor_id()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
+
         $this->assertEquals('[sponsor]', $account->getSponsorId());
     }
 
@@ -361,7 +440,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_missing_sponsor_id()
     {
-        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
+        $account = AccountResource::wrap(
+            Response::fake('account_without_data')->getBody()
+        );
+
         $this->assertNull($account->getSponsorId());
     }
 
@@ -371,7 +453,9 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_low_threshold()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
 
         $this->assertInstanceOf(UInt32::class, $account->getLowThreshold());
         $this->assertEquals(1, $account->getLowThreshold()->toNativeInt());
@@ -383,7 +467,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_zero_for_missing_low_threshold()
     {
-        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
+        $account = AccountResource::wrap(
+            Response::fake('account_without_data')->getBody()
+        );
+
         $this->assertEquals(0, $account->getLowThreshold()->toNativeInt());
     }
 
@@ -393,7 +480,9 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_medium_threshold()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
 
         $this->assertInstanceOf(UInt32::class, $account->getMediumThreshold());
         $this->assertEquals(2, $account->getMediumThreshold()->toNativeInt());
@@ -405,7 +494,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_zero_for_missing_medium_threshold()
     {
-        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
+        $account = AccountResource::wrap(
+            Response::fake('account_without_data')->getBody()
+        );
+
         $this->assertEquals(0, $account->getMediumThreshold()->toNativeInt());
     }
 
@@ -415,7 +507,9 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_high_threshold()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
 
         $this->assertInstanceOf(UInt32::class, $account->getHighThreshold());
         $this->assertEquals(3, $account->getHighThreshold()->toNativeInt());
@@ -427,7 +521,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_zero_for_missing_high_threshold()
     {
-        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
+        $account = AccountResource::wrap(
+            Response::fake('account_without_data')->getBody()
+        );
+
         $this->assertEquals(0, $account->getHighThreshold()->toNativeInt());
     }
 
@@ -437,7 +534,9 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_flags()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
         $expected = [
             'auth_required'         => true,
             'auth_revocable'        => true,
@@ -454,7 +553,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_an_empty_array_for_missing_flags()
     {
-        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
+        $account = AccountResource::wrap(
+            Response::fake('account_without_data')->getBody()
+        );
+
         $this->assertEquals([], $account->getFlags());
     }
 
@@ -464,7 +566,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_auth_immutable_flag()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
+
         $this->assertTrue($account->getAuthImmutableFlag());
     }
 
@@ -474,7 +579,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_missing_auth_immutable_flag()
     {
-        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
+        $account = AccountResource::wrap(
+            Response::fake('account_without_data')->getBody()
+        );
+
         $this->assertNull($account->getAuthImmutableFlag());
     }
 
@@ -484,7 +592,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_auth_required_flag()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
+
         $this->assertTrue($account->getAuthRequiredFlag());
     }
 
@@ -494,7 +605,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_missing_auth_required_flag()
     {
-        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
+        $account = AccountResource::wrap(
+            Response::fake('account_without_data')->getBody()
+        );
+
         $this->assertNull($account->getAuthRequiredFlag());
     }
 
@@ -504,7 +618,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_auth_revocable_flag()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
+
         $this->assertTrue($account->getAuthRevocableFlag());
     }
 
@@ -514,7 +631,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_missing_auth_revocable_flag()
     {
-        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
+        $account = AccountResource::wrap(
+            Response::fake('account_without_data')->getBody()
+        );
+
         $this->assertNull($account->getAuthRevocableFlag());
     }
 
@@ -524,7 +644,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_auth_clawback_enabled_flag()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
+
         $this->assertTrue($account->getAuthClawbackEnabledFlag());
     }
 
@@ -534,7 +657,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_missing_auth_clawback_enabled_flag()
     {
-        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
+        $account = AccountResource::wrap(
+            Response::fake('account_without_data')->getBody()
+        );
+
         $this->assertNull($account->getAuthClawbackEnabledFlag());
     }
 
@@ -544,7 +670,9 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_account_balances()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
         $expected = [
             'balance'             => '10000.0000000',
             'buying_liabilities'  => '0.0000000',
@@ -562,7 +690,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_an_empty_array_for_missing_balances()
     {
-        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
+        $account = AccountResource::wrap(
+            Response::fake('account_without_data')->getBody()
+        );
+
         $this->assertEquals([], $account->getBalances());
     }
 
@@ -572,7 +703,9 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_a_balance_for_a_given_asset_if_it_is_present()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
         $balance = $account->getBalanceForAsset('USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5');
 
         $this->assertInstanceOf(AccountBalanceResource::class, $balance);
@@ -586,7 +719,9 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_a_balance_for_the_native_asset()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
         $balance = $account->getBalanceForAsset('XLM');
 
         $this->assertInstanceOf(AccountBalanceResource::class, $balance);
@@ -600,7 +735,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_null_for_a_missing_asset()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
+
         $this->assertNull($account->getBalanceForAsset('FooBar:GBVG2QOHHFBVHAEGNF4XRUCAPAGWDROONM2LC4BK4ECCQ5RTQOO64VBW'));
     }
 
@@ -610,7 +748,9 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_signers()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
         $expected = [
             'weight' => 1,
             'key'    => '[address]',
@@ -627,7 +767,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_an_empty_array_for_missing_signers()
     {
-        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
+        $account = AccountResource::wrap(
+            Response::fake('account_without_data')->getBody()
+        );
+
         $this->assertEquals([], $account->getSigners());
     }
 
@@ -637,7 +780,9 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_the_data_fields_array()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
         $expected = [
             'foo' => 'bar',
         ];
@@ -651,7 +796,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_returns_an_empty_array_for_missing_data_fields()
     {
-        $account = AccountResource::fromResponse(Response::fake('account_without_data'));
+        $account = AccountResource::wrap(
+            Response::fake('account_without_data')->getBody()
+        );
+
         $this->assertEquals([], $account->getData());
     }
 
@@ -661,7 +809,10 @@ class AccountResourceTest extends TestCase
      */
     public function it_can_return_a_specific_data_key_value()
     {
-        $account = AccountResource::fromResponse(Response::fake('retrieve_account'));
+        $account = AccountResource::wrap(
+            Response::fake('retrieve_account')->getBody()
+        );
+
         $this->assertEquals('bar', $account->getData('foo'));
     }
 }

--- a/tests/Horizon/AccountSignerResourceTest.php
+++ b/tests/Horizon/AccountSignerResourceTest.php
@@ -25,10 +25,10 @@ class AccountSignerResourceTest extends TestCase
      */
     public function it_returns_the_signer_weight()
     {
-        $resource = AccountSignerResource::fromArray(self::SIGNER_EXAMPLE);
+        $resource = AccountSignerResource::wrap(self::SIGNER_EXAMPLE);
         $this->assertEquals(10, $resource->getWeight()->toNativeInt());
 
-        $resource = AccountSignerResource::fromArray([]);
+        $resource = AccountSignerResource::wrap([]);
         $this->assertEquals(0, $resource->getWeight()->toNativeInt());
     }
 
@@ -38,13 +38,13 @@ class AccountSignerResourceTest extends TestCase
      */
     public function it_returns_the_sponsor_address_if_present()
     {
-        $resource = AccountSignerResource::fromArray(self::SIGNER_EXAMPLE);
+        $resource = AccountSignerResource::wrap(self::SIGNER_EXAMPLE);
         $this->assertEquals(
             'GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U',
             $resource->getSponsor()
         );
 
-        $resource = AccountSignerResource::fromArray([]);
+        $resource = AccountSignerResource::wrap([]);
         $this->assertNull($resource->getSponsor());
     }
 
@@ -54,13 +54,13 @@ class AccountSignerResourceTest extends TestCase
      */
     public function it_returns_the_key_if_present()
     {
-        $resource = AccountSignerResource::fromArray(self::SIGNER_EXAMPLE);
+        $resource = AccountSignerResource::wrap(self::SIGNER_EXAMPLE);
         $this->assertEquals(
             'GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U',
             $resource->getKey()
         );
 
-        $resource = AccountSignerResource::fromArray([]);
+        $resource = AccountSignerResource::wrap([]);
         $this->assertNull($resource->getKey());
     }
 
@@ -70,10 +70,10 @@ class AccountSignerResourceTest extends TestCase
      */
     public function it_returns_the_signer_type_if_present()
     {
-        $resource = AccountSignerResource::fromArray(self::SIGNER_EXAMPLE);
+        $resource = AccountSignerResource::wrap(self::SIGNER_EXAMPLE);
         $this->assertEquals('ed25519_public_key', $resource->getType());
 
-        $resource = AccountSignerResource::fromArray([]);
+        $resource = AccountSignerResource::wrap([]);
         $this->assertNull($resource->getType());
     }
 }

--- a/tests/Horizon/ResourceCollectionTest.php
+++ b/tests/Horizon/ResourceCollectionTest.php
@@ -17,11 +17,20 @@ class ResourceCollectionTest extends TestCase
     /**
      * @test
      * @covers ::__construct
+     */
+    public function it_will_be_constructed_with_an_empty_payload()
+    {
+        $this->assertEquals([], (new ResourceCollection())->toArray());
+    }
+
+    /**
+     * @test
+     * @covers ::wrap
      * @covers ::getResourceClass
      */
-    public function it_can_be_instantiated_with_an_array_payload()
+    public function it_can_wrap_an_array()
     {
-        $collection = new ResourceCollection([
+        $collection = ResourceCollection::wrap([
             '_embedded' => [
                 'records' => [
                     ['foo' => 'bar'],
@@ -38,33 +47,12 @@ class ResourceCollectionTest extends TestCase
 
     /**
      * @test
-     * @covers ::__construct
+     * @covers ::wrap
      * @covers ::getResourceClass
      */
-    public function it_can_be_instantiated_from_a_json_string()
+    public function it_can_wrap_a_json_string()
     {
-        $collection = new ResourceCollection('{"_embedded":{"records":[{"foo":"bar"},{"foo":"bar"}]}}');
-
-        $this->assertInstanceOf(ResourceCollection::class, $collection);
-        foreach ($collection as $resource) {
-            $this->assertInstanceOf(Resource::class, $resource);
-        }
-    }
-
-    /**
-     * @test
-     * @covers ::fromArray
-     */
-    public function it_can_be_instantiated_from_an_array()
-    {
-        $collection = ResourceCollection::fromArray([
-            '_embedded' => [
-                'records' => [
-                    ['foo' => 'bar'],
-                    ['foo' => 'bar']
-                ]
-            ]
-        ]);
+        $collection = ResourceCollection::wrap('{"_embedded":{"records":[{"foo":"bar"},{"foo":"bar"}]}}');
 
         $this->assertInstanceOf(ResourceCollection::class, $collection);
         foreach ($collection as $resource) {
@@ -173,7 +161,7 @@ class ResourceCollectionTest extends TestCase
     public function it_knows_when_it_is_empty()
     {
         $collectionA = ResourceCollection::fromResponse(Response::fake('account_transactions'));
-        $collectionB = new ResourceCollection();
+        $collectionB = ResourceCollection::wrap([]);
 
         $this->assertFalse($collectionA->isEmpty());
         $this->assertTrue($collectionB->isEmpty());

--- a/tests/Horizon/TransactionResourceTest.php
+++ b/tests/Horizon/TransactionResourceTest.php
@@ -36,7 +36,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_self_link()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('friendbot_transaction')->getBody()
+        );
         $expected = 'https://horizon-testnet.stellar.org/transactions/[hash]';
 
         $this->assertEquals($expected, $transaction->getSelfLink());
@@ -48,7 +50,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_account_link()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction', ['address' => 'ABCD']));
+        $transaction = TransactionResource::wrap(
+            Response::fake('friendbot_transaction', ['address' => 'ABCD'])->getBody()
+        );
         $expected = 'https://horizon-testnet.stellar.org/accounts/ABCD';
 
         $this->assertEquals($expected, $transaction->getAccountLink());
@@ -60,7 +64,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_ledger_link()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('friendbot_transaction')->getBody()
+        );
         $expected = 'https://horizon-testnet.stellar.org/ledgers/994571';
 
         $this->assertEquals($expected, $transaction->getLedgerLink());
@@ -72,7 +78,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_operations_link()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('friendbot_transaction')->getBody()
+        );
         $expected = 'https://horizon-testnet.stellar.org/transactions/[hash]/operations{?cursor,limit,order}';
 
         $this->assertEquals($expected, $transaction->getOperationsLink());
@@ -84,7 +92,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_effects_link()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('friendbot_transaction')->getBody()
+        );
         $expected = 'https://horizon-testnet.stellar.org/transactions/[hash]/effects{?cursor,limit,order}';
 
         $this->assertEquals($expected, $transaction->getEffectsLink());
@@ -96,7 +106,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_precedes_link()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('friendbot_transaction')->getBody()
+        );
         $expected = 'https://horizon-testnet.stellar.org/transactions?order=asc&cursor=4271649918558208';
 
         $this->assertEquals($expected, $transaction->getPrecedesLink());
@@ -108,7 +120,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_succeeds_link()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('friendbot_transaction')->getBody()
+        );
         $expected = 'https://horizon-testnet.stellar.org/transactions?order=desc&cursor=4271649918558208';
 
         $this->assertEquals($expected, $transaction->getSucceedsLink());
@@ -120,7 +134,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_transaction_id()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('friendbot_transaction')->getBody()
+        );
         $expected = '[hash]';
 
         $this->assertEquals($expected, $transaction->getId());
@@ -132,7 +148,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_paging_token()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('friendbot_transaction')->getBody()
+        );
         $expected = '4271649918558208';
 
         $this->assertEquals($expected, $transaction->getPagingToken());
@@ -144,7 +162,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_success_status()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('friendbot_transaction')->getBody()
+        );
         $this->assertTrue($transaction->wasSuccessful());
     }
 
@@ -154,7 +174,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_transaction_hash()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('friendbot_transaction')->getBody()
+        );
         $expected = '[hash]';
 
         $this->assertEquals($expected, $transaction->getHash());
@@ -166,7 +188,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_ledger_sequence()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('friendbot_transaction')->getBody()
+        );
         $expected = '994571';
 
         $this->assertEquals($expected, $transaction->getLedgerSequence());
@@ -178,7 +202,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_created_at_date()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('friendbot_transaction')->getBody()
+        );
         $expected = new \DateTime('2022-05-15T21:41:56Z');
 
         $this->assertEquals($expected, $transaction->getCreatedAt());
@@ -190,7 +216,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_null_for_created_at_if_no_date_is_present()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('transaction_without_created_at'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('transaction_without_created_at')->getBody()
+        );
         $this->assertNull($transaction->getCreatedAt());
     }
 
@@ -200,7 +228,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_source_account_address()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction', ['address' => 'ABCD']));
+        $transaction = TransactionResource::wrap(
+            Response::fake('friendbot_transaction', ['address' => 'ABCD'])->getBody()
+        );
         $expected = 'ABCD';
 
         $this->assertEquals($expected, $transaction->getSourceAccountAddress());
@@ -212,7 +242,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_source_account_sequence()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('friendbot_transaction')->getBody()
+        );
         $expected = '3133127102824503';
 
         $this->assertEquals($expected, $transaction->getSourceAccountSequence());
@@ -224,7 +256,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_fee_charged()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('friendbot_transaction')->getBody()
+        );
         $this->assertEquals('0.0010000', $transaction->getFeeCharged()->toNativeString());
     }
 
@@ -234,7 +268,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_null_for_missing_fee_charged()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('transaction_without_fee_charged'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('transaction_without_fee_charged')->getBody()
+        );
         $this->assertNull($transaction->getFeeCharged());
     }
 
@@ -244,7 +280,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_max_fee()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('friendbot_transaction')->getBody()
+        );
         $this->assertEquals('0.1000000', $transaction->getMaxFee()->toNativeString());
     }
 
@@ -254,7 +292,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_null_for_missing_max_fee()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('transaction_without_max_fee'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('transaction_without_max_fee')->getBody()
+        );
         $this->assertNull($transaction->getMaxFee());
     }
 
@@ -264,7 +304,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_operation_count()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('friendbot_transaction')->getBody()
+        );
         $this->assertEquals(1, $transaction->getOperationCount());
     }
 
@@ -274,7 +316,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_envelope_xdr()
     {
-        $transactionResource = TransactionResource::fromResponse(Response::fake('transaction_submitted'));
+        $transactionResource = TransactionResource::wrap(
+            Response::fake('transaction_submitted')->getBody()
+        );
         $expected = '[envelope_xdr]';
 
         $this->assertEquals($expected, $transactionResource->getEnvelopeXdr());
@@ -301,9 +345,14 @@ class TransactionResourceTest extends TestCase
             ->withSignatures($signatureList);
         $buffer = XDR::fresh()->write($envelope);
 
-        $transactionResource = TransactionResource::fromResponse(Response::fake('transaction_submitted', [
-            'envelope_xdr' => $buffer->toBase64()
-        ]));
+        $transactionResource = TransactionResource::wrap(
+            Response::fake(
+                'transaction_submitted',
+                [
+                    'envelope_xdr' => $buffer->toBase64()
+                ]
+            )->getBody()
+        );
 
         $decoded = $transactionResource->getEnvelope();
 
@@ -316,7 +365,9 @@ class TransactionResourceTest extends TestCase
      */
     public function the_envelope_returns_null_if_xdr_decoding_fails()
     {
-        $transactionResource = TransactionResource::fromResponse(Response::fake('transaction_submitted'));
+        $transactionResource = TransactionResource::wrap(
+            Response::fake('transaction_submitted')->getBody()
+        );
         $this->assertNull($transactionResource->getEnvelope());
     }
 
@@ -326,7 +377,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_result_xdr()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('friendbot_transaction')->getBody()
+        );
         $expected = 'AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=';
 
         $this->assertEquals($expected, $transaction->getResultXdr());
@@ -338,8 +391,10 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_decoded_result()
     {
-        $transactionA = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
-        $transactionB = new TransactionResource();
+        $transactionA = TransactionResource::wrap(
+            Response::fake('friendbot_transaction')->getBody()
+        );
+        $transactionB = TransactionResource::wrap([]);
 
         $this->assertInstanceOf(TransactionResult::class, $transactionA->getResult());
         $this->assertNull($transactionB->getResult());
@@ -351,7 +406,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_result_meta_xdr()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('friendbot_transaction')->getBody()
+        );
         $expected = 'AAAAAgAAAAIAAAADABZvBAAAAAAAAAAAvVwFT3+rSlZXIxuRDhJnGNK1hmUGgR7Iz1Fs6Mi8yPgAAAAAPDNgHAAWaesAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABABZvBAAAAAAAAAAAvVwFT3+rSlZXIxuRDhJnGNK1hmUGgR7Iz1Fs6Mi8yPgAAAAAPDNgHAAWaesAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAwAAAAAAFm8EAAAAAGOXevYAAAAAAAAAAQAAAAMAAAADABZvAgAAAAAAAAAAEH3Rayw4M0iCLoEe96rPFNGYim8AVHJU0z4ebYZW4JwAXyFoHjXfuAAAATsAAAHXAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAwAAAAAAFmoCAAAAAGOXYMUAAAAAAAAAAQAWbwQAAAAAAAAAABB90WssODNIgi6BHveqzxTRmIpvAFRyVNM+Hm2GVuCcAF8hUNW+97gAAAE7AAAB1wAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAMAAAAAABZqAgAAAABjl2DFAAAAAAAAAAAAFm8EAAAAAAAAAACgG04mjMWmD5gmfeWpY2/Ogov+50UUsejfFOdqR9nGMAAAABdIdugAABZvBAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAA=';
 
         $this->assertEquals($expected, $transaction->getResultMetaXdr());
@@ -363,8 +420,10 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_decoded_result_meta()
     {
-        $transactionA = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
-        $transactionB = new TransactionResource();
+        $transactionA = TransactionResource::wrap(
+            Response::fake('friendbot_transaction')->getBody()
+        );
+        $transactionB = TransactionResource::wrap([]);
 
         $this->assertInstanceOf(TransactionMeta::class, $transactionA->getResultMeta());
         $this->assertNull($transactionB->getResultMeta());
@@ -376,7 +435,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_fee_meta_xdr()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('friendbot_transaction')->getBody()
+        );
         $expected = 'AAAAAgAAAAMAFmnrAAAAAAAAAAC9XAVPf6tKVlcjG5EOEmcY0rWGZQaBHsjPUWzoyLzI+AAAAAA8M2CAABZp6wAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAFm8EAAAAAAAAAAC9XAVPf6tKVlcjG5EOEmcY0rWGZQaBHsjPUWzoyLzI+AAAAAA8M2AcABZp6wAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==';
 
         $this->assertEquals($expected, $transaction->getFeeMetaXdr());
@@ -388,8 +449,10 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_decoded_fee_meta()
     {
-        $transactionA = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
-        $transactionB = new TransactionResource();
+        $transactionA = TransactionResource::wrap(
+            Response::fake('friendbot_transaction')->getBody()
+        );
+        $transactionB = TransactionResource::wrap([]);
 
         $this->assertInstanceOf(OperationMeta::class, $transactionA->getFeeMeta());
         $this->assertNull($transactionB->getFeeMeta());
@@ -401,7 +464,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_memo()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_text_memo'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('transaction_with_text_memo')->getBody()
+        );
         $expected = '298424';
 
         $this->assertEquals($expected, $transaction->getMemo());
@@ -413,7 +478,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_memo_type()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_text_memo'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('transaction_with_text_memo')->getBody()
+        );
         $expected = 'text';
 
         $this->assertEquals($expected, $transaction->getMemoType());
@@ -425,7 +492,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_signatures()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('friendbot_transaction'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('friendbot_transaction')->getBody()
+        );
         $expected = [
             "[signature1]",
             "[signature2]"
@@ -440,7 +509,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_preconditions()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_preconditions'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('transaction_with_preconditions')->getBody()
+        );
         $expected = [
             'time_bounds'                     => [
                 'min_time' => '1643673600',
@@ -468,7 +539,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_min_time_condition()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_preconditions'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('transaction_with_preconditions')->getBody()
+        );
         $expected = new \Datetime('@1643673600');
 
         $this->assertEquals($expected, $transaction->getMinTimeCondition());
@@ -480,7 +553,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_null_for_a_min_time_condition_of_zero()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_preconditions_alt'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('transaction_with_preconditions_alt')->getBody()
+        );
 
         $this->assertNull($transaction->getMinTimeCondition());
     }
@@ -491,7 +566,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_max_time_condition()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_preconditions'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('transaction_with_preconditions')->getBody()
+        );
         $expected = new \Datetime('@1643673600');
 
         $this->assertEquals($expected, $transaction->getMaxTimeCondition());
@@ -503,7 +580,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_null_for_a_max_time_condition_of_zero()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_preconditions_alt'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('transaction_with_preconditions_alt')->getBody()
+        );
         $this->assertNull($transaction->getMaxTimeCondition());
     }
 
@@ -513,7 +592,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_min_ledger_condition()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_preconditions'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('transaction_with_preconditions')->getBody()
+        );
         $expected = 100;
 
         $this->assertEquals($expected, $transaction->getMinLedgerCondition());
@@ -525,7 +606,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_max_ledger_condition()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_preconditions'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('transaction_with_preconditions')->getBody()
+        );
         $expected = 200;
 
         $this->assertEquals($expected, $transaction->getMaxLedgerCondition());
@@ -537,7 +620,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_min_account_sequence_condition()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_preconditions'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('transaction_with_preconditions')->getBody()
+        );
         $expected = Int64::of('100');
 
         $this->assertEquals($expected, $transaction->getMinAccountSequenceCondition());
@@ -549,7 +634,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_min_account_sequence_age_condition()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_preconditions'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('transaction_with_preconditions')->getBody()
+        );
         $expected = UInt64::of('200');
 
         $this->assertTrue($expected->isEqualTo($transaction->getMinAccountSequenceAgeCondition()));
@@ -561,7 +648,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_null_for_a_missing_min_account_sequence_age_condition()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_preconditions_alt'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('transaction_with_preconditions_alt')->getBody()
+        );
 
         $this->assertNull($transaction->getMinAccountSequenceAgeCondition());
     }
@@ -572,7 +661,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_min_account_sequence_ledger_gap_condition()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_preconditions'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('transaction_with_preconditions')->getBody()
+        );
         $expected = 1;
 
         $this->assertEquals($expected, $transaction->getMinAccountSequenceLedgerGapCondition());
@@ -584,7 +675,9 @@ class TransactionResourceTest extends TestCase
      */
     public function it_returns_the_extra_signers_condition()
     {
-        $transaction = TransactionResource::fromResponse(Response::fake('transaction_with_preconditions'));
+        $transaction = TransactionResource::wrap(
+            Response::fake('transaction_with_preconditions')->getBody()
+        );
         $expected = [
             'SIGNERA',
             'SIGNERB',


### PR DESCRIPTION
This PR adjusts the structure of Resource classes to simplify how they are instantiated and adjust their usage to be more in line with practices used elsewhere in this library.   All instantiation will now happen via a `wrap` static method rather than via a constructor.  Additionally, the `wrap` method will accept all possible input types, rather than using a different instantiation method for each input type.  For the sake of readability, the `fromResponse` helper method has been retained for cosmetic purposes.